### PR TITLE
TagBuilder multiline support

### DIFF
--- a/src/components/DropdownField/index.tsx
+++ b/src/components/DropdownField/index.tsx
@@ -229,7 +229,9 @@ function getSingleContent(item: string | DropdownFieldItem, theme?: any) {
   );
 }
 
-const MultipleDropdownItem = styled(StyledTagItem as any)``;
+const MultipleDropdownItem = styled(StyledTagItem as any)`
+  margin: 0 ${distance.small} 0 0;
+`;
 
 function getMultipleContent(item: string | DropdownFieldItem, theme?: any) {
   const key = typeof item === 'string' ? item : item.key;

--- a/src/components/InputInfo/__snapshots__/InputInfo.test.tsx.snap
+++ b/src/components/InputInfo/__snapshots__/InputInfo.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`<InputInfo /> should be shown with the withValidation hoc if not change
                     hasValue={false}
                   >
                     <div
-                      className="sc-cSHVUG fGfMCz"
+                      className="sc-cSHVUG VvHrU"
                     >
                       <Component
                         error={false}
@@ -45,7 +45,7 @@ exports[`<InputInfo /> should be shown with the withValidation hoc if not change
                       >
                         <styled.div>
                           <div
-                            className="sc-VigVT glTrhf"
+                            className="sc-VigVT bviReV"
                           >
                             <styled.input
                               innerRef={[Function]}
@@ -127,7 +127,7 @@ exports[`<InputInfo /> should not be shown with the withValidation hoc if change
                     hasValue={false}
                   >
                     <div
-                      className="sc-cSHVUG fGfMCz"
+                      className="sc-cSHVUG VvHrU"
                     >
                       <Component
                         error={false}
@@ -137,7 +137,7 @@ exports[`<InputInfo /> should not be shown with the withValidation hoc if change
                       >
                         <styled.div>
                           <div
-                            className="sc-VigVT glTrhf"
+                            className="sc-VigVT bviReV"
                           >
                             <styled.input
                               innerRef={[Function]}

--- a/src/components/TagBuilder/Example.md
+++ b/src/components/TagBuilder/Example.md
@@ -76,3 +76,11 @@ const tagRenderer = e => (<Button type={e.index % 2 === 0 ? "primary" : "seconda
   tagRenderer={tagRenderer}
 />
 ```
+
+TagBuilder component is also capable of handling a large amount of tags.
+
+```jsx
+const { TagBuilder } = require('precise-ui');
+
+<TagBuilder defaultValue={['Velit','irure','proident','occaecat','eu','excepteur','proident','dolor','ad','cillum','amet','consequat','in.','Reprehenderit','irure','officia','excepteur','et','laborum','proident','veniam','tempor.','Ad','quis','est','commodo','minim','sunt','incididunt','aute','amet','minim','incididunt','irure','cupidatat','officia','irure.','Dolor','adipisicing','occaecat','quis','ut','nulla','aliquip','esse']}/>
+```

--- a/src/components/TagBuilder/__snapshots__/TagBuilder.test.tsx.snap
+++ b/src/components/TagBuilder/__snapshots__/TagBuilder.test.tsx.snap
@@ -15,10 +15,12 @@ exports[`<TagBuilderInt /> should render component with empty value 1`] = `
     >
       <styled.div
         labelShown={false}
+        tagRenderer={false}
       >
         <styled.div
           key="input"
           onKeyDown={[Function]}
+          tagRenderer={false}
         >
           <styled.input
             innerRef={[Function]}
@@ -26,6 +28,7 @@ exports[`<TagBuilderInt /> should render component with empty value 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             type="text"
+            valid={true}
             value=""
           />
         </styled.div>
@@ -56,8 +59,9 @@ exports[`<TagBuilderInt /> should render component with error block and default 
     >
       <styled.div
         labelShown={false}
+        tagRenderer={false}
       >
-        <styled.span
+        <Styled(styled.span)
           key="tags0"
         >
           <styled.span>
@@ -66,8 +70,8 @@ exports[`<TagBuilderInt /> should render component with error block and default 
           <CloseIcon
             onClick={[Function]}
           />
-        </styled.span>
-        <styled.span
+        </Styled(styled.span)>
+        <Styled(styled.span)
           key="list1"
         >
           <styled.span>
@@ -76,8 +80,8 @@ exports[`<TagBuilderInt /> should render component with error block and default 
           <CloseIcon
             onClick={[Function]}
           />
-        </styled.span>
-        <styled.span
+        </Styled(styled.span)>
+        <Styled(styled.span)
           key="goes2"
         >
           <styled.span>
@@ -86,8 +90,8 @@ exports[`<TagBuilderInt /> should render component with error block and default 
           <CloseIcon
             onClick={[Function]}
           />
-        </styled.span>
-        <styled.span
+        </Styled(styled.span)>
+        <Styled(styled.span)
           key="here3"
         >
           <styled.span>
@@ -96,10 +100,11 @@ exports[`<TagBuilderInt /> should render component with error block and default 
           <CloseIcon
             onClick={[Function]}
           />
-        </styled.span>
+        </Styled(styled.span)>
         <styled.div
           key="input"
           onKeyDown={[Function]}
+          tagRenderer={false}
         >
           <styled.input
             innerRef={[Function]}
@@ -107,6 +112,7 @@ exports[`<TagBuilderInt /> should render component with error block and default 
             onChange={[Function]}
             onFocus={[Function]}
             type="text"
+            valid={true}
             value=""
           />
         </styled.div>
@@ -138,8 +144,9 @@ exports[`<TagBuilderInt /> should render component with info block and value 1`]
     >
       <styled.div
         labelShown={false}
+        tagRenderer={false}
       >
-        <styled.span
+        <Styled(styled.span)
           key="tags0"
         >
           <styled.span>
@@ -148,8 +155,8 @@ exports[`<TagBuilderInt /> should render component with info block and value 1`]
           <CloseIcon
             onClick={[Function]}
           />
-        </styled.span>
-        <styled.span
+        </Styled(styled.span)>
+        <Styled(styled.span)
           key="list1"
         >
           <styled.span>
@@ -158,8 +165,8 @@ exports[`<TagBuilderInt /> should render component with info block and value 1`]
           <CloseIcon
             onClick={[Function]}
           />
-        </styled.span>
-        <styled.span
+        </Styled(styled.span)>
+        <Styled(styled.span)
           key="goes2"
         >
           <styled.span>
@@ -168,8 +175,8 @@ exports[`<TagBuilderInt /> should render component with info block and value 1`]
           <CloseIcon
             onClick={[Function]}
           />
-        </styled.span>
-        <styled.span
+        </Styled(styled.span)>
+        <Styled(styled.span)
           key="here3"
         >
           <styled.span>
@@ -178,10 +185,11 @@ exports[`<TagBuilderInt /> should render component with info block and value 1`]
           <CloseIcon
             onClick={[Function]}
           />
-        </styled.span>
+        </Styled(styled.span)>
         <styled.div
           key="input"
           onKeyDown={[Function]}
+          tagRenderer={false}
         >
           <styled.input
             innerRef={[Function]}
@@ -189,6 +197,7 @@ exports[`<TagBuilderInt /> should render component with info block and value 1`]
             onChange={[Function]}
             onFocus={[Function]}
             type="text"
+            valid={true}
             value=""
           />
         </styled.div>
@@ -219,10 +228,12 @@ exports[`<TagBuilderInt /> should render the component 1`] = `
     >
       <styled.div
         labelShown={false}
+        tagRenderer={false}
       >
         <styled.div
           key="input"
           onKeyDown={[Function]}
+          tagRenderer={false}
         >
           <styled.input
             innerRef={[Function]}
@@ -230,6 +241,7 @@ exports[`<TagBuilderInt /> should render the component 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             type="text"
+            valid={true}
             value=""
           />
         </styled.div>

--- a/src/quarks/StyledInputBox.tsx
+++ b/src/quarks/StyledInputBox.tsx
@@ -38,9 +38,11 @@ export const StyledInputBox: React.ComponentClass<StyledInputBoxProps> = reStyle
   align-items: center;
   flex: 1;
   background: ${ui2};
-  height: 54px;
+  min-height: 54px;
+  max-height: 112px;
   border-bottom: 1px solid ${border === TextFieldBorderType.error ? purpleRed : focused ? ui0 : hasValue ? ui5 : ui3};
   cursor: ${disabled ? 'not-allowed' : 'auto'};
+  overflow-y: scroll;
 
   &:hover {
     border-bottom-color: ${disabled ? ui3 : ui0};

--- a/src/quarks/StyledInputRow.tsx
+++ b/src/quarks/StyledInputRow.tsx
@@ -11,6 +11,7 @@ const TextFieldBoxWithLabelWrapper = styled.div`
   height: 100%;
   position: relative;
   min-width: 0;
+  margin: auto;
 `;
 
 const TextFieldLabel = styled.label`

--- a/src/quarks/StyledTagItem.tsx
+++ b/src/quarks/StyledTagItem.tsx
@@ -8,12 +8,10 @@ export interface StyledTagItemProps {
 }
 
 export const StyledTagItem: React.ComponentClass<StyledTagItemProps> = styled.span`
-  margin: 0 ${distance.small} 0 0;
   padding: ${distance.xsmall} ${distance.small};
   background-color: ${themed(props => props.theme.ui4)};
   color: ${themed(props => props.theme.tagColor)};
   display: inline-block;
-  border-radius: 3px;
   font-size: 0.8em;
   line-height: 0.8em;
   border: 0;


### PR DESCRIPTION
## TagBuilder multiline support

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

This feature is meant to solve the issue when heaving overflowing tags inside the TagBuilder.
With default tagRenderer, the component shows up to 3 lines of tags without scrollbar.

Another improvement is the tag validation coloring, meaning that, in case of writing the same tag again, instead of just disabling addition of the tag, color of the input filed changes to purple red.
