### PR TITLE
fixed Expander size after expanded

### DIFF
--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -565,18 +565,21 @@ exports[`<Accordion /> should render a <Accordion> component with several tabs i
                         unmountOnExit={true}
                       >
                         <styled.div
+                          expandedHeight={0}
                           innerRef={[Function]}
+                          status="entering"
                           style={
                             Object {
-                              "minHeight": "0px",
+                              "minHeight": undefined,
                             }
                           }
+                          timeout={300}
                         >
                           <div
-                            className="sc-bwzfXH kuqbRN"
+                            className="sc-bwzfXH gHSgQq"
                             style={
                               Object {
-                                "minHeight": "0px",
+                                "minHeight": undefined,
                               }
                             }
                           >


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

`Expander` component used in `Accordion` was assigning exact value to the animated container after animation played. That caused a problem when content was changing but it's container was still the same size. This bugfix set `height: 'auto'` just after animation played and returns an absolute height value to the container just before it should be collapsed.
