### PR TITLE
FileUploaderDetails custom translation

### DIFF
--- a/src/components/FileUploaderDetails/Example.md
+++ b/src/components/FileUploaderDetails/Example.md
@@ -14,6 +14,7 @@ class FileUploaderDetailsExample extends React.Component {
     this.cancelUpload = this.cancelUpload.bind(this);
     this.makeProgress = this.makeProgress.bind(this);
     this.onClose = this.onClose.bind(this);
+    this.errorShown = false;
   }
 
   uploadStart({ files: startedFiles }) {
@@ -36,7 +37,7 @@ class FileUploaderDetailsExample extends React.Component {
 
     if (file) {
       const uploaderId = file.uploaderId;
-      const timeout = (Math.floor(Math.random() * Math.floor(3)) + 1) * 1000;
+      const timeout = (Math.floor(Math.random() * 3) + 1) * 1000;
       const currentProgress = file.progress || 0;
 
       if (currentProgress < 100 && !file.canceled && !file.error) {
@@ -46,13 +47,27 @@ class FileUploaderDetailsExample extends React.Component {
         if (file.progress < 100) {
           setTimeout(() => this.makeProgress(id), timeout);
         } else {
-          this.eventManager.emit(FileUploadActions.uploadSuccess, { files: [file] });
+          if (!this.errorShown) {
+            this.errorShown = true;
+            this.eventManager.emit(FileUploadActions.uploadFailure, { files: [{...file, error: 'upload_204'}] });
+          } else {
+            this.eventManager.emit(FileUploadActions.uploadSuccess, { files: [file] });
+          }
         }
       }
 
       this.files[file.fileId] = file;
     }
   };
+
+  translate(error) {
+    switch(error) {
+      case 'upload_204':
+        return 'Localized message for error 204';
+      default:
+        return `No localization for ${error}`;
+    }
+  }
 
   onClose() {
     this.files = {};
@@ -67,6 +82,7 @@ class FileUploaderDetailsExample extends React.Component {
           onUpload={this.uploadStart}
           onCancel={this.cancelUpload}
           onClose={this.onClose}
+          translate={this.translate}
         />
         <FileUploader
           multiple

--- a/src/components/FileUploaderDetails/FileUploaderDetails.types.part.ts
+++ b/src/components/FileUploaderDetails/FileUploaderDetails.types.part.ts
@@ -73,3 +73,9 @@ export interface FileUploaderDetailsEvent<T> {
    */
   files: Array<T>;
 }
+export interface Translate {
+  /**
+   * Optionally provide custom translate function to be used for unhandled custom error messages
+   */
+  translate?(str: string): string;
+}

--- a/src/components/FileUploaderDetails/StatusTable.part.tsx
+++ b/src/components/FileUploaderDetails/StatusTable.part.tsx
@@ -5,7 +5,7 @@ import { Icon } from '../Icon';
 import { ProgressBar } from '../ProgressBar';
 import { Table, TableCellEvent, TableRowEvent } from '../Table';
 import { ActionIconContainer } from './ActionIconContainer.part';
-import { FileProgress, FileUploaderDetailsEvent } from './FileUploaderDetails.types.part';
+import { FileProgress, FileUploaderDetailsEvent, Translate } from './FileUploaderDetails.types.part';
 import { StatusIcon } from './StatusIcon.part';
 import { getStatus, iconNames } from './helpers';
 import { StandardProps } from '../../common';
@@ -56,7 +56,7 @@ export const StyledTableRow = reStyled.tr<StyledTableRowProps>(
 `,
 );
 
-export interface StatusTableProps extends StandardProps {
+export interface StatusTableProps extends StandardProps, Translate {
   files: Array<FileProgress>;
   onCancel(e: FileUploaderDetailsEvent<FileProgress>): void;
   onDelete(e: FileUploaderDetailsEvent<FileProgress>): void;
@@ -69,7 +69,18 @@ export interface StatusTableProps extends StandardProps {
   errorTableUploadLabel?: string;
 }
 
-export const StatusTable: React.SFC<StatusTableProps> = ({ theme, files, onCancel, onDelete, ...props }) => {
+function defaultTranslate(error: any) {
+  return typeof error === 'string' ? error : 'Missing translation';
+}
+
+export const StatusTable: React.SFC<StatusTableProps> = ({
+  theme,
+  files,
+  onCancel,
+  onDelete,
+  translate = defaultTranslate,
+  ...props
+}) => {
   const columns = {
     name: {
       header: getPropLabel(props, 'tableHeaderFileLabel'),
@@ -133,7 +144,7 @@ export const StatusTable: React.SFC<StatusTableProps> = ({ theme, files, onCance
       return (
         <TextWrapBox>
           <StatusIcon condensed type={status} name={iconNames[value]} />
-          {error || getPropLabel(props, `${status}TableUploadLabel` as any)}
+          {(error && translate(error)) || getPropLabel(props, `${status}TableUploadLabel` as any)}
         </TextWrapBox>
       );
     }

--- a/src/components/FileUploaderDetails/UploaderProgressDetails.part.tsx
+++ b/src/components/FileUploaderDetails/UploaderProgressDetails.part.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled from '../../utils/styled';
 import { getPropLabel, UploadProgressDetailsLabels } from '../../utils/labels';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '../Modal';
-import { FileProgress, FileUploaderDetailsEvent } from './FileUploaderDetails.types.part';
+import { FileProgress, FileUploaderDetailsEvent, Translate } from './FileUploaderDetails.types.part';
 import { StatusTable } from './StatusTable.part';
 import { IconLink } from '../IconLink';
 
@@ -15,7 +15,7 @@ const StyledModal = styled(Modal)`
   max-width: 600px;
 `;
 
-export interface UploaderProgressDetailsProps extends UploadProgressDetailsLabels {
+export interface UploaderProgressDetailsProps extends UploadProgressDetailsLabels, Translate {
   /**
    * Determines if the details are shown or not.
    */

--- a/src/components/FileUploaderDetails/index.tsx
+++ b/src/components/FileUploaderDetails/index.tsx
@@ -8,15 +8,16 @@ import {
   FileProgress,
   FileUploadActions,
   FileUploaderDetailsEvent,
+  Translate,
 } from './FileUploaderDetails.types.part';
 import { UploaderProgressBar } from './UploaderProgressBar.part';
 import { UploaderProgressDetails } from './UploaderProgressDetails.part';
 import { mergeData } from './helpers';
 import { distance } from '../../distance';
 
-export { FileUploadActions, FileItem, FileProgress, FileBase, FileUploaderDetailsEvent };
+export { FileUploadActions, FileItem, FileProgress, FileBase, FileUploaderDetailsEvent, Translate };
 
-export interface FileUploaderDetailsProps extends UploadProgressDetailsLabels, UploaderProgressBarLabels {
+export interface FileUploaderDetailsProps extends UploadProgressDetailsLabels, UploaderProgressBarLabels, Translate {
   /**
    * Sets the event manager to use. By default a standard event manager is used.
    */


### PR DESCRIPTION
## FileUploaderDetails custom translation

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Currently we have the problem, that when a consumer application uses the FileUploaderDetails, custom error messages do not get localized, only the known labels, and this feature is allowing consumers to define their custom translate function which would be called with the error string passed to the file object.
