### PR TITLE
FileUploaderDetails with new getLabel prop

### DIFF
--- a/src/components/Dropzone/index.tsx
+++ b/src/components/Dropzone/index.tsx
@@ -337,6 +337,7 @@ class DropzoneInt extends React.Component<DropzoneProps & FormContextProps, Drop
       onChange: _2,
       preview: _3,
       children,
+      onOpen: _4,
       ...props
     } = this.props;
 

--- a/src/components/FileUploaderDetails/Example.md
+++ b/src/components/FileUploaderDetails/Example.md
@@ -54,6 +54,24 @@ class FileUploaderDetailsExample extends React.Component {
     }
   };
 
+  getLabel(info) {
+    const { type, data } = info;
+    if (type === 'error') {
+      switch(data) {
+        case 'upload_204':
+          return 'Localized message for error 204';
+        default:
+          return `No localization for ${error}`;
+      }
+    }
+    switch(data) {
+      case 'successTableUploadLabel':
+        return 'Custom success label';
+      default:
+        return ''
+    }
+  }
+
   onClose() {
     this.files = {};
   };
@@ -67,6 +85,7 @@ class FileUploaderDetailsExample extends React.Component {
           onUpload={this.uploadStart}
           onCancel={this.cancelUpload}
           onClose={this.onClose}
+          getLabel={this.getLabel}
         />
         <FileUploader
           multiple

--- a/src/components/FileUploaderDetails/StatusTable.part.tsx
+++ b/src/components/FileUploaderDetails/StatusTable.part.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled, { reStyled, themed } from '../../utils/styled';
-import { getPropLabel } from '../../utils/labels';
+import { buildGetLabels, GetLabel } from '../../utils/labels';
 import { Icon } from '../Icon';
 import { ProgressBar } from '../ProgressBar';
 import { Table, TableCellEvent, TableRowEvent } from '../Table';
@@ -56,7 +56,7 @@ export const StyledTableRow = reStyled.tr<StyledTableRowProps>(
 `,
 );
 
-export interface StatusTableProps extends StandardProps {
+export interface StatusTableProps extends StandardProps, GetLabel {
   files: Array<FileProgress>;
   onCancel(e: FileUploaderDetailsEvent<FileProgress>): void;
   onDelete(e: FileUploaderDetailsEvent<FileProgress>): void;
@@ -67,15 +67,16 @@ export interface StatusTableProps extends StandardProps {
   progressTableUploadLabel?: string;
   successTableUploadLabel?: string;
   errorTableUploadLabel?: string;
+  [key: string]: any;
 }
 
 export const StatusTable: React.SFC<StatusTableProps> = ({ theme, files, onCancel, onDelete, ...props }) => {
   const columns = {
     name: {
-      header: getPropLabel(props, 'tableHeaderFileLabel'),
+      header: buildGetLabels(props)('tableHeaderFileLabel'),
     },
     status: {
-      header: getPropLabel(props, 'tableHeaderStatusLabel'),
+      header: buildGetLabels(props)('tableHeaderStatusLabel'),
       width: '40%',
     },
     action: {
@@ -133,7 +134,7 @@ export const StatusTable: React.SFC<StatusTableProps> = ({ theme, files, onCance
       return (
         <TextWrapBox>
           <StatusIcon condensed type={status} name={iconNames[value]} />
-          {error || getPropLabel(props, `${status}TableUploadLabel` as any)}
+          {buildGetLabels(props)(error ? { type: 'error', data: error } : `${status}TableUploadLabel`)}
         </TextWrapBox>
       );
     }

--- a/src/components/FileUploaderDetails/UploaderProgressDetails.part.tsx
+++ b/src/components/FileUploaderDetails/UploaderProgressDetails.part.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled from '../../utils/styled';
-import { getPropLabel, UploadProgressDetailsLabels } from '../../utils/labels';
+import { getPropLabel, UploadProgressDetailsLabels, GetLabel } from '../../utils/labels';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '../Modal';
 import { FileProgress, FileUploaderDetailsEvent } from './FileUploaderDetails.types.part';
 import { StatusTable } from './StatusTable.part';
@@ -15,7 +15,7 @@ const StyledModal = styled(Modal)`
   max-width: 600px;
 `;
 
-export interface UploaderProgressDetailsProps extends UploadProgressDetailsLabels {
+export interface UploaderProgressDetailsProps extends UploadProgressDetailsLabels, GetLabel {
   /**
    * Determines if the details are shown or not.
    */

--- a/src/components/FileUploaderDetails/index.tsx
+++ b/src/components/FileUploaderDetails/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled from '../../utils/styled';
-import { UploadProgressDetailsLabels, UploaderProgressBarLabels } from '../../utils/labels';
+import { UploadProgressDetailsLabels, UploaderProgressBarLabels, GetLabel } from '../../utils/labels';
 import { EventManager, eventManagers } from '../../utils/eventManager';
 import {
   FileBase,
@@ -14,9 +14,9 @@ import { UploaderProgressDetails } from './UploaderProgressDetails.part';
 import { mergeData } from './helpers';
 import { distance } from '../../distance';
 
-export { FileUploadActions, FileItem, FileProgress, FileBase, FileUploaderDetailsEvent };
+export { FileUploadActions, FileItem, FileProgress, FileBase, FileUploaderDetailsEvent, GetLabel };
 
-export interface FileUploaderDetailsProps extends UploadProgressDetailsLabels, UploaderProgressBarLabels {
+export interface FileUploaderDetailsProps extends UploadProgressDetailsLabels, UploaderProgressBarLabels, GetLabel {
   /**
    * Sets the event manager to use. By default a standard event manager is used.
    */

--- a/src/utils/labels.ts
+++ b/src/utils/labels.ts
@@ -118,3 +118,26 @@ export function getPropLabel<TProps, TKey extends keyof TProps>(
 
   return value;
 }
+
+export interface LabelInfo {
+  type: 'info' | 'error';
+  data: any;
+}
+
+export interface GetLabel {
+  getLabel?(info: LabelInfo): string;
+}
+
+export function buildGetLabels<TProps extends GetLabel, TKey extends keyof TProps>(props: TProps) {
+  const { getLabel } = props;
+  return (info: ({ type: 'info' | 'error'; data: TKey & string }) | (TKey & string)) => {
+    if (typeof info === 'string') {
+      return (getLabel && getLabel({ type: 'info', data: info })) || getPropLabel(props, info) || info;
+    }
+    if (typeof info === 'object' && info.data) {
+      return (getLabel && getLabel(info)) || getPropLabel(props, info.data) || info.data;
+    }
+
+    return '';
+  };
+}


### PR DESCRIPTION
## FileUploaderDetails with new getLabel prop

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Extending the capability of the current approach when it comes to displaying custom labels through the new optional prop `getLabel`, which allows consumers to handle custom labels, or overwrite existing ones.
