### PR TITLE
Dropdown feature: open / position direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed: missed selection state of `RadioButtonGroup` in non-controlled mode with form context.
 - Compatibility with IE11
 - Fixed: component wrapped with `withValidation` hoc didn't display an error
+- Feature: new Dropdown props (open / direction)
 
 ## 0.5.0
 

--- a/src/components/DropdownField/Dropdown.test.tsx
+++ b/src/components/DropdownField/Dropdown.test.tsx
@@ -51,6 +51,21 @@ describe('<DropdownField />', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should be opened <DropdownField open>', () => {
+    const wrapper = enzyme.mount(<DropdownField open data={['1', '2']} defaultValue="1" borderless />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should be opened towards the top <DropdownField open direction={1}>', () => {
+    const wrapper = enzyme.mount(<DropdownField open direction={1} data={['1', '2']} defaultValue="1" borderless />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should be opened towards the bottom <DropdownField open direction={0}>', () => {
+    const wrapper = enzyme.mount(<DropdownField open direction={0} data={['1', '2']} defaultValue="1" borderless />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('clicking the div toggles the dropdown', () => {
     let clicked = false;
     let status = 'close';

--- a/src/components/DropdownField/DropdownField.types.part.tsx
+++ b/src/components/DropdownField/DropdownField.types.part.tsx
@@ -1,4 +1,5 @@
 import { InputChangeEvent, LabeledInputProps } from '../../common';
+import { InteractiveListDirection } from '../InteractiveList';
 
 export interface DropdownFieldToggleEvent {
   state: 'open' | 'close';
@@ -12,7 +13,9 @@ export interface DropdownFieldItem {
   searchText?: string;
   type?: 'item' | 'divider' | 'header';
 }
+
 ``;
+
 export interface DropdownFieldProps extends LabeledInputProps<string | Array<string>> {
   /**
    * @ignore
@@ -29,14 +32,17 @@ export interface DropdownFieldProps extends LabeledInputProps<string | Array<str
    * @default 8
    */
   maxSelectedShown?: number;
+
   /**
    * Fired when the dropdown gets opened or closed.
    */
   onToggle?(e: DropdownFieldToggleEvent): void;
+
   /**
    * Fired once the selected value changes.
    */
   onChange?(e: DropdownFieldChangeEvent): void;
+
   /**
    * The data to be displayed as selection basis.
    */
@@ -46,4 +52,15 @@ export interface DropdownFieldProps extends LabeledInputProps<string | Array<str
    * @default false
    */
   borderless?: boolean;
+
+  /**
+   * Whether to open dropdown list to top or bottom.
+   * If not provided then opens depending on the screen size.
+   */
+  direction?: InteractiveListDirection;
+
+  /**
+   * Allows to open dropdown immediately after initializing.
+   */
+  open?: boolean;
 }

--- a/src/components/DropdownField/DropdownFieldInt.tsx
+++ b/src/components/DropdownField/DropdownFieldInt.tsx
@@ -17,6 +17,7 @@ import {
   InteractiveListWrapperProps,
   InteractiveListDirection,
   InteractiveListBorderType,
+  InteractiveListProps,
 } from '../InteractiveList';
 import {
   StyledInputRow,
@@ -217,7 +218,7 @@ export class DropdownFieldInt extends React.Component<DropdownFieldProps & FormC
 
     this.state = {
       value: getIndices(data, value, props.multiple),
-      open: false,
+      open: props.open === true,
       controlled: props.value !== undefined,
       error: props.error,
     };
@@ -337,7 +338,7 @@ export class DropdownFieldInt extends React.Component<DropdownFieldProps & FormC
   };
 
   private renderList = (screenSize?: ScreenSize) => {
-    const { data = [], theme, disabled, multiple } = this.props;
+    const { data = [], theme, disabled, multiple, direction } = this.props;
     const { open, value } = this.state;
     const mobile = screenSize === 'small';
     const wrapper = mobile ? getMobileWrapper(<StyledLabel>{this.props.label}</StyledLabel>) : StandardWrapper;
@@ -355,7 +356,8 @@ export class DropdownFieldInt extends React.Component<DropdownFieldProps & FormC
         indices={value}
         customWrapper={wrapper}
         onClickOutside={() => {}}
-        autoPosition
+        direction={direction}
+        autoPosition={undefined === direction}
         autoFocus
       />
     );

--- a/src/components/DropdownField/Example.md
+++ b/src/components/DropdownField/Example.md
@@ -20,6 +20,16 @@ const items = [
 <DropdownField data={items} defaultValue="Value 1" label="Select item"/>
 ```
 
+**Positioning**
+
+By default the list is positioned automatically based on the screen size (whether towards the top or bottom, depending on available space on the screen). There is an option to override this behavior by `direction` prop (`0` - bottom, `1` - top).
+
+```jsx
+const { DropdownField } = require('precise-ui');
+
+<DropdownField data={['first', 'second']} direction={0}/>
+```
+
 **Decoration Options**
 
 The given items can also be more than just values. We can provide complex objects that contain further information such as an optional item type (e.g., `divider`, `header`) or some fixed content.

--- a/src/components/DropdownField/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/DropdownField/__snapshots__/Dropdown.test.tsx.snap
@@ -1,5 +1,4325 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<DropdownField /> should be opened <DropdownField open> 1`] = `
+<DropdownFieldInt
+  borderless={true}
+  data={
+    Array [
+      "1",
+      "2",
+    ]
+  }
+  defaultValue="1"
+  open={true}
+>
+  <styled.div
+    open={true}
+  >
+    <StyledComponent
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "sc-jlyJG",
+            "isStatic": true,
+            "lastClassName": "XpIWY",
+            "rules": Array [
+              "
+  position: relative;
+  outline: 0;
+",
+            ],
+          },
+          "displayName": "styled.div",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "sc-jlyJG",
+          "target": "div",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+      open={true}
+    >
+      <div
+        className="sc-jlyJG XpIWY"
+        open={true}
+      >
+        <styled.div
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          tabIndex={0}
+        >
+          <StyledComponent
+            forwardedComponent={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "sc-gipzik",
+                  "isStatic": true,
+                  "lastClassName": "bxGTeT",
+                  "rules": Array [
+                    "
+  display: flex;
+",
+                  ],
+                },
+                "displayName": "styled.div",
+                "foldedComponentIds": Array [],
+                "render": [Function],
+                "styledComponentId": "sc-gipzik",
+                "target": "div",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              }
+            }
+            forwardedRef={null}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            tabIndex={0}
+          >
+            <div
+              className="sc-gipzik bxGTeT"
+              onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              tabIndex={0}
+            >
+              <Styled(styled.div)
+                border={0}
+                focused={true}
+                hasValue={true}
+              >
+                <StyledComponent
+                  border={0}
+                  focused={true}
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "sc-csuQGl",
+                        "isStatic": false,
+                        "lastClassName": "kMIMiT",
+                        "rules": Array [
+                          [Function],
+                          "
+  border: 1px solid ",
+                          [Function],
+                          ";
+",
+                        ],
+                      },
+                      "displayName": "Styled(styled.div)",
+                      "foldedComponentIds": Array [
+                        "sc-jzJRlG",
+                      ],
+                      "render": [Function],
+                      "styledComponentId": "sc-csuQGl",
+                      "target": "div",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                  hasValue={true}
+                >
+                  <div
+                    className="sc-jzJRlG sc-csuQGl kMIMiT"
+                  >
+                    <Component
+                      error={false}
+                      focused={true}
+                      hasValue={true}
+                    >
+                      <styled.div>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "sc-gqjmRU",
+                                "isStatic": true,
+                                "lastClassName": "lohXgE",
+                                "rules": Array [
+                                  "
+  flex-grow: 1;
+  display: flex;
+  flex-flow: column-reverse;
+  height: 100%;
+  position: relative;
+  min-width: 0;
+  margin: auto;
+",
+                                ],
+                              },
+                              "displayName": "styled.div",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "sc-gqjmRU",
+                              "target": "div",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <div
+                            className="sc-gqjmRU lohXgE"
+                          >
+                            <styled.div
+                              labelShown={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "sc-Rmtcm",
+                                      "isStatic": false,
+                                      "lastClassName": "iZdMBl",
+                                      "rules": Array [
+                                        "
+  ",
+                                        "
+    ",
+                                        "font-size: 1rem;
+  ",
+                                        "
+    ",
+                                        "line-height: 1.375rem;
+  ",
+                                        "
+    ",
+                                        "
+  ",
+                                        "
+  padding: ",
+                                        [Function],
+                                        ";
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  color: ",
+                                        [Function],
+                                        ";
+  font-family: inherit;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  cursor: ",
+                                        [Function],
+                                        ";
+",
+                                      ],
+                                    },
+                                    "displayName": "styled.div",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "sc-Rmtcm",
+                                    "target": "div",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                labelShown={false}
+                              >
+                                <div
+                                  className="sc-Rmtcm iZdMBl"
+                                >
+                                  <styled.span
+                                    key="1"
+                                  >
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "sc-bRBYWo",
+                                            "isStatic": false,
+                                            "lastClassName": "jelrwS",
+                                            "rules": Array [
+                                              "
+  display: inline-block;
+  line-height: normal;
+  border: 0;
+  color: ",
+                                              [Function],
+                                              ";
+",
+                                            ],
+                                          },
+                                          "displayName": "styled.span",
+                                          "foldedComponentIds": Array [],
+                                          "render": [Function],
+                                          "styledComponentId": "sc-bRBYWo",
+                                          "target": "span",
+                                          "toString": [Function],
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
+                                      }
+                                      forwardedRef={null}
+                                    >
+                                      <span
+                                        className="sc-bRBYWo jelrwS"
+                                      >
+                                        1
+                                      </span>
+                                    </StyledComponent>
+                                  </styled.span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </div>
+                        </StyledComponent>
+                      </styled.div>
+                    </Component>
+                    <Component
+                      hasValue={true}
+                    />
+                    <styled.div>
+                      <StyledComponent
+                        forwardedComponent={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "sc-gZMcBi",
+                              "isStatic": true,
+                              "lastClassName": "YVZuN",
+                              "rules": Array [
+                                "
+  padding: 0 ",
+                                "1rem",
+                                ";
+
+  i {
+    display: block;
+  }
+
+  & + & {
+    padding-left: 0;
+  }
+",
+                              ],
+                            },
+                            "displayName": "styled.div",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "sc-gZMcBi",
+                            "target": "div",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          }
+                        }
+                        forwardedRef={null}
+                      >
+                        <div
+                          className="sc-gZMcBi YVZuN"
+                        >
+                          <Icon
+                            color="rgba(75,78,82,1)"
+                            name="KeyboardArrowUp"
+                            size="22px"
+                          >
+                            <styled.i>
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "sc-htpNat",
+                                      "isStatic": true,
+                                      "lastClassName": "jgiceE",
+                                      "rules": Array [
+                                        "
+  display: inline-block;
+
+  > svg {
+    float: left;
+  }
+",
+                                      ],
+                                    },
+                                    "displayName": "styled.i",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "sc-htpNat",
+                                    "target": "i",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                              >
+                                <i
+                                  className="sc-htpNat jgiceE"
+                                >
+                                  <KeyboardArrowUp
+                                    height="22px"
+                                    style={
+                                      Object {
+                                        "fill": "rgba(75,78,82,1)",
+                                        "stroke": undefined,
+                                      }
+                                    }
+                                    viewBox="0 0 24 24"
+                                    width="22px"
+                                  >
+                                    <svg
+                                      height="22px"
+                                      style={
+                                        Object {
+                                          "fill": "rgba(75,78,82,1)",
+                                          "stroke": undefined,
+                                        }
+                                      }
+                                      viewBox="0 0 24 24"
+                                      width="22px"
+                                    >
+                                      <path
+                                        d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"
+                                      />
+                                    </svg>
+                                  </KeyboardArrowUp>
+                                </i>
+                              </StyledComponent>
+                            </styled.i>
+                          </Icon>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </div>
+                </StyledComponent>
+              </Styled(styled.div)>
+            </div>
+          </StyledComponent>
+        </styled.div>
+        <Responsive
+          render={[Function]}
+        >
+          <InteractiveList
+            autoFocus={true}
+            autoPosition={true}
+            customWrapper={[Function]}
+            data={
+              Array [
+                "1",
+                "2",
+              ]
+            }
+            eventTypes={
+              Array [
+                "mousedown",
+                "touchstart",
+              ]
+            }
+            excludeScrollbar={false}
+            indices={
+              Array [
+                0,
+              ]
+            }
+            onChange={[Function]}
+            onClick={[Function]}
+            onClickOutside={[Function]}
+            onKeyDown={[Function]}
+            open={true}
+            outsideClickIgnoreClass="ignore-react-onclickoutside"
+            preventDefault={false}
+            stopPropagation={false}
+          >
+            <InteractiveListInt
+              autoFocus={true}
+              autoPosition={true}
+              customWrapper={[Function]}
+              data={
+                Array [
+                  "1",
+                  "2",
+                ]
+              }
+              disableOnClickOutside={[Function]}
+              enableOnClickOutside={[Function]}
+              eventTypes={
+                Array [
+                  "mousedown",
+                  "touchstart",
+                ]
+              }
+              indices={
+                Array [
+                  0,
+                ]
+              }
+              onChange={[Function]}
+              onClick={[Function]}
+              onClickOutside={[Function]}
+              onKeyDown={[Function]}
+              open={true}
+              outsideClickIgnoreClass="ignore-react-onclickoutside"
+              preventDefault={false}
+              stopPropagation={false}
+            >
+              <styled.div
+                autoFocus={true}
+                autoPosition={true}
+                disableOnClickOutside={[Function]}
+                enableOnClickOutside={[Function]}
+                eventTypes={
+                  Array [
+                    "mousedown",
+                    "touchstart",
+                  ]
+                }
+                onKeyDown={[Function]}
+                outsideClickIgnoreClass="ignore-react-onclickoutside"
+                preventDefault={false}
+                stopPropagation={false}
+                tabIndex={0}
+              >
+                <StyledComponent
+                  autoFocus={true}
+                  autoPosition={true}
+                  disableOnClickOutside={[Function]}
+                  enableOnClickOutside={[Function]}
+                  eventTypes={
+                    Array [
+                      "mousedown",
+                      "touchstart",
+                    ]
+                  }
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "sc-hSdWYo",
+                        "isStatic": true,
+                        "lastClassName": "bUjOem",
+                        "rules": Array [
+                          "
+  position: relative;
+  outline: none;
+",
+                        ],
+                      },
+                      "displayName": "styled.div",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "sc-hSdWYo",
+                      "target": "div",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={[Function]}
+                  onKeyDown={[Function]}
+                  outsideClickIgnoreClass="ignore-react-onclickoutside"
+                  preventDefault={false}
+                  stopPropagation={false}
+                  tabIndex={0}
+                >
+                  <div
+                    autoFocus={true}
+                    className="sc-hSdWYo bUjOem"
+                    onKeyDown={[Function]}
+                    tabIndex={0}
+                  >
+                    <Component
+                      border={1}
+                      direction={0}
+                      onClick={[Function]}
+                      open={true}
+                    >
+                      <Styled(WindowPopup)
+                        label={<ForwardRef />}
+                        onClose={[Function]}
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "sc-fBuWsC",
+                                "isStatic": true,
+                                "lastClassName": "eySOLS",
+                                "rules": Array [
+                                  "
+  border: 2em solid transparent;
+",
+                                ],
+                              },
+                              "displayName": "Styled(WindowPopup)",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "sc-fBuWsC",
+                              "target": [Function],
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          label={<ForwardRef />}
+                          onClose={[Function]}
+                        >
+                          <WindowPopup
+                            className="sc-fBuWsC eySOLS"
+                            label={<ForwardRef />}
+                            onClose={[Function]}
+                          >
+                            <Blocker
+                              className="sc-fBuWsC eySOLS"
+                              onClose={[Function]}
+                            >
+                              <styled.div
+                                className="sc-fBuWsC eySOLS"
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                              >
+                                <StyledComponent
+                                  className="sc-fBuWsC eySOLS"
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "sc-chPdSV",
+                                        "isStatic": true,
+                                        "lastClassName": "juaCGL",
+                                        "rules": Array [
+                                          "
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  position: fixed;
+  z-index: 10000;
+  overflow-x: hidden;
+  overflow-y: auto;
+",
+                                        ],
+                                      },
+                                      "displayName": "styled.div",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "sc-chPdSV",
+                                      "target": "div",
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={[Function]}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                >
+                                  <div
+                                    className="sc-fBuWsC eySOLS sc-chPdSV juaCGL"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                  >
+                                    <styled.a
+                                      href="#"
+                                      onFocus={[Function]}
+                                    >
+                                      <StyledComponent
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "sc-kgoBCf",
+                                              "isStatic": true,
+                                              "lastClassName": "ccpxKu",
+                                              "rules": Array [
+                                                "
+  height: 0;
+  width: 0;
+  overflow: hidden;
+",
+                                              ],
+                                            },
+                                            "displayName": "styled.a",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "sc-kgoBCf",
+                                            "target": "a",
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
+                                        href="#"
+                                        onFocus={[Function]}
+                                      >
+                                        <a
+                                          className="sc-kgoBCf ccpxKu"
+                                          href="#"
+                                          onFocus={[Function]}
+                                        />
+                                      </StyledComponent>
+                                    </styled.a>
+                                    <styled.div
+                                      tabIndex={0}
+                                    >
+                                      <StyledComponent
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "sc-dxgOiQ",
+                                              "isStatic": false,
+                                              "lastClassName": "dyHuYR",
+                                              "rules": Array [
+                                                "
+  padding: ",
+                                                "1rem",
+                                                ";
+  box-sizing: border-box;
+  height: 100%;
+  overflow-y: auto;
+  background: ",
+                                                [Function],
+                                                ";
+",
+                                              ],
+                                            },
+                                            "displayName": "styled.div",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "sc-dxgOiQ",
+                                            "target": "div",
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
+                                        tabIndex={0}
+                                      >
+                                        <div
+                                          className="sc-dxgOiQ dyHuYR"
+                                          tabIndex={0}
+                                        >
+                                          <styled.div>
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-jKJlTe",
+                                                    "isStatic": false,
+                                                    "lastClassName": "cKsVkt",
+                                                    "rules": Array [
+                                                      "
+  ",
+                                                      "
+    ",
+                                                      "font-size: 0.875rem;
+  ",
+                                                      "
+    ",
+                                                      "line-height: 1.125rem;
+  ",
+                                                      "
+    ",
+                                                      "
+  ",
+                                                      "
+
+  color: ",
+                                                      [Function],
+                                                      ";
+  padding-bottom: ",
+                                                      "1rem",
+                                                      ";
+  min-height: ",
+                                                      "0.875rem",
+                                                      ";
+",
+                                                    ],
+                                                  },
+                                                  "displayName": "styled.div",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-jKJlTe",
+                                                  "target": "div",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                            >
+                                              <div
+                                                className="sc-jKJlTe cKsVkt"
+                                              >
+                                                <styled.div>
+                                                  <StyledComponent
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-jhAzac",
+                                                          "isStatic": true,
+                                                          "lastClassName": "gwtcyj",
+                                                          "rules": Array [
+                                                            "
+  padding-left: ",
+                                                            "1rem",
+                                                            ";
+",
+                                                          ],
+                                                        },
+                                                        "displayName": "styled.div",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-jhAzac",
+                                                        "target": "div",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                  >
+                                                    <div
+                                                      className="sc-jhAzac gwtcyj"
+                                                    />
+                                                  </StyledComponent>
+                                                </styled.div>
+                                              </div>
+                                            </StyledComponent>
+                                          </styled.div>
+                                          <CloseButton
+                                            onClick={[Function]}
+                                          >
+                                            <styled.a
+                                              onClick={[Function]}
+                                            >
+                                              <StyledComponent
+                                                forwardedComponent={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "attrs": Array [],
+                                                    "componentStyle": ComponentStyle {
+                                                      "componentId": "sc-kpOJdX",
+                                                      "isStatic": true,
+                                                      "lastClassName": "kxReIc",
+                                                      "rules": Array [
+                                                        "
+  ",
+                                                        "
+    ",
+                                                        "font-size: 1rem;
+  ",
+                                                        "
+    ",
+                                                        "line-height: 1.375rem;
+  ",
+                                                        "
+    ",
+                                                        "
+  ",
+                                                        "
+
+  position: absolute;
+  top: ",
+                                                        "1rem",
+                                                        ";
+  right: ",
+                                                        "1rem",
+                                                        ";
+  background-color: ",
+                                                        "rgba(255, 255, 255, 0)",
+                                                        ";
+  padding: 0;
+  border: none;
+  align-self: start;
+  cursor: pointer;
+  color: ",
+                                                        "rgba(0,0,0,1)",
+                                                        ";
+  opacity: 0.2;
+  transition: opacity 0.2s ease-out;
+
+  &:hover {
+    opacity: 0.5;
+  }
+",
+                                                      ],
+                                                    },
+                                                    "displayName": "styled.a",
+                                                    "foldedComponentIds": Array [],
+                                                    "render": [Function],
+                                                    "styledComponentId": "sc-kpOJdX",
+                                                    "target": "a",
+                                                    "toString": [Function],
+                                                    "warnTooManyClasses": [Function],
+                                                    "withComponent": [Function],
+                                                  }
+                                                }
+                                                forwardedRef={null}
+                                                onClick={[Function]}
+                                              >
+                                                <a
+                                                  className="sc-kpOJdX kxReIc"
+                                                  onClick={[Function]}
+                                                >
+                                                  <Icon
+                                                    name="Close"
+                                                    size={1.1}
+                                                  >
+                                                    <styled.i>
+                                                      <StyledComponent
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "sc-htpNat",
+                                                              "isStatic": true,
+                                                              "lastClassName": "jgiceE",
+                                                              "rules": Array [
+                                                                "
+  display: inline-block;
+
+  > svg {
+    float: left;
+  }
+",
+                                                              ],
+                                                            },
+                                                            "displayName": "styled.i",
+                                                            "foldedComponentIds": Array [],
+                                                            "render": [Function],
+                                                            "styledComponentId": "sc-htpNat",
+                                                            "target": "i",
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
+                                                          }
+                                                        }
+                                                        forwardedRef={null}
+                                                      >
+                                                        <i
+                                                          className="sc-htpNat jgiceE"
+                                                        >
+                                                          <Close
+                                                            height="1.1em"
+                                                            style={
+                                                              Object {
+                                                                "fill": "currentColor",
+                                                                "stroke": undefined,
+                                                              }
+                                                            }
+                                                            viewBox="0 0 24 24"
+                                                            width="1.1em"
+                                                          >
+                                                            <svg
+                                                              height="1.1em"
+                                                              style={
+                                                                Object {
+                                                                  "fill": "currentColor",
+                                                                  "stroke": undefined,
+                                                                }
+                                                              }
+                                                              viewBox="0 0 24 24"
+                                                              width="1.1em"
+                                                            >
+                                                              <path
+                                                                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                              />
+                                                            </svg>
+                                                          </Close>
+                                                        </i>
+                                                      </StyledComponent>
+                                                    </styled.i>
+                                                  </Icon>
+                                                </a>
+                                              </StyledComponent>
+                                            </styled.a>
+                                          </CloseButton>
+                                          <styled.div>
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-ckVGcZ",
+                                                    "isStatic": true,
+                                                    "lastClassName": "fvuixH",
+                                                    "rules": Array [
+                                                      "
+  box-sizing: border-box;
+  margin: 0;
+",
+                                                    ],
+                                                  },
+                                                  "displayName": "styled.div",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-ckVGcZ",
+                                                  "target": "div",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                            >
+                                              <div
+                                                className="sc-ckVGcZ fvuixH"
+                                              >
+                                                <styled.li
+                                                  hovered={false}
+                                                  key="1-0"
+                                                  onClick={[Function]}
+                                                  onMouseMove={[Function]}
+                                                  selected={true}
+                                                >
+                                                  <StyledComponent
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-cvbbAY",
+                                                          "isStatic": false,
+                                                          "lastClassName": "eAHqky",
+                                                          "rules": Array [
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "displayName": "styled.li",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-cvbbAY",
+                                                        "target": "li",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={[Function]}
+                                                    hovered={false}
+                                                    onClick={[Function]}
+                                                    onMouseMove={[Function]}
+                                                    selected={true}
+                                                  >
+                                                    <li
+                                                      className="sc-cvbbAY eAHqky"
+                                                      onClick={[Function]}
+                                                      onMouseMove={[Function]}
+                                                      selected={true}
+                                                    >
+                                                      <styled.div>
+                                                        <StyledComponent
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-jWBwVP",
+                                                                "isStatic": true,
+                                                                "lastClassName": "jZcPPp",
+                                                                "rules": Array [
+                                                                  "
+  display: flex;
+  align-items: center;
+",
+                                                                ],
+                                                              },
+                                                              "displayName": "styled.div",
+                                                              "foldedComponentIds": Array [],
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-jWBwVP",
+                                                              "target": "div",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                        >
+                                                          <div
+                                                            className="sc-jWBwVP jZcPPp"
+                                                          >
+                                                            <styled.div>
+                                                              <StyledComponent
+                                                                forwardedComponent={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "attrs": Array [],
+                                                                    "componentStyle": ComponentStyle {
+                                                                      "componentId": "sc-brqgnP",
+                                                                      "isStatic": true,
+                                                                      "lastClassName": "jgYEci",
+                                                                      "rules": Array [
+                                                                        "
+  flex-grow: 1;
+",
+                                                                      ],
+                                                                    },
+                                                                    "displayName": "styled.div",
+                                                                    "foldedComponentIds": Array [],
+                                                                    "render": [Function],
+                                                                    "styledComponentId": "sc-brqgnP",
+                                                                    "target": "div",
+                                                                    "toString": [Function],
+                                                                    "warnTooManyClasses": [Function],
+                                                                    "withComponent": [Function],
+                                                                  }
+                                                                }
+                                                                forwardedRef={null}
+                                                              >
+                                                                <div
+                                                                  className="sc-brqgnP jgYEci"
+                                                                >
+                                                                  <styled.div
+                                                                    condensed={false}
+                                                                    showTick={false}
+                                                                  >
+                                                                    <StyledComponent
+                                                                      condensed={false}
+                                                                      forwardedComponent={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "attrs": Array [],
+                                                                          "componentStyle": ComponentStyle {
+                                                                            "componentId": "sc-cMljjf",
+                                                                            "isStatic": false,
+                                                                            "lastClassName": "gZZzyn",
+                                                                            "rules": Array [
+                                                                              "
+  padding: ",
+                                                                              [Function],
+                                                                              ";
+  ",
+                                                                              [Function],
+                                                                              ";
+",
+                                                                            ],
+                                                                          },
+                                                                          "displayName": "styled.div",
+                                                                          "foldedComponentIds": Array [],
+                                                                          "render": [Function],
+                                                                          "styledComponentId": "sc-cMljjf",
+                                                                          "target": "div",
+                                                                          "toString": [Function],
+                                                                          "warnTooManyClasses": [Function],
+                                                                          "withComponent": [Function],
+                                                                        }
+                                                                      }
+                                                                      forwardedRef={null}
+                                                                      showTick={false}
+                                                                    >
+                                                                      <div
+                                                                        className="sc-cMljjf gZZzyn"
+                                                                      >
+                                                                        1
+                                                                      </div>
+                                                                    </StyledComponent>
+                                                                  </styled.div>
+                                                                </div>
+                                                              </StyledComponent>
+                                                            </styled.div>
+                                                          </div>
+                                                        </StyledComponent>
+                                                      </styled.div>
+                                                    </li>
+                                                  </StyledComponent>
+                                                </styled.li>
+                                                <styled.li
+                                                  hovered={false}
+                                                  key="2-1"
+                                                  onClick={[Function]}
+                                                  onMouseMove={[Function]}
+                                                  selected={false}
+                                                >
+                                                  <StyledComponent
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-cvbbAY",
+                                                          "isStatic": false,
+                                                          "lastClassName": "eAHqky",
+                                                          "rules": Array [
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "displayName": "styled.li",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-cvbbAY",
+                                                        "target": "li",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={[Function]}
+                                                    hovered={false}
+                                                    onClick={[Function]}
+                                                    onMouseMove={[Function]}
+                                                    selected={false}
+                                                  >
+                                                    <li
+                                                      className="sc-cvbbAY eAHqky"
+                                                      onClick={[Function]}
+                                                      onMouseMove={[Function]}
+                                                      selected={false}
+                                                    >
+                                                      <styled.div>
+                                                        <StyledComponent
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-jWBwVP",
+                                                                "isStatic": true,
+                                                                "lastClassName": "jZcPPp",
+                                                                "rules": Array [
+                                                                  "
+  display: flex;
+  align-items: center;
+",
+                                                                ],
+                                                              },
+                                                              "displayName": "styled.div",
+                                                              "foldedComponentIds": Array [],
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-jWBwVP",
+                                                              "target": "div",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                        >
+                                                          <div
+                                                            className="sc-jWBwVP jZcPPp"
+                                                          >
+                                                            <styled.div>
+                                                              <StyledComponent
+                                                                forwardedComponent={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "attrs": Array [],
+                                                                    "componentStyle": ComponentStyle {
+                                                                      "componentId": "sc-brqgnP",
+                                                                      "isStatic": true,
+                                                                      "lastClassName": "jgYEci",
+                                                                      "rules": Array [
+                                                                        "
+  flex-grow: 1;
+",
+                                                                      ],
+                                                                    },
+                                                                    "displayName": "styled.div",
+                                                                    "foldedComponentIds": Array [],
+                                                                    "render": [Function],
+                                                                    "styledComponentId": "sc-brqgnP",
+                                                                    "target": "div",
+                                                                    "toString": [Function],
+                                                                    "warnTooManyClasses": [Function],
+                                                                    "withComponent": [Function],
+                                                                  }
+                                                                }
+                                                                forwardedRef={null}
+                                                              >
+                                                                <div
+                                                                  className="sc-brqgnP jgYEci"
+                                                                >
+                                                                  <styled.div
+                                                                    condensed={false}
+                                                                    showTick={false}
+                                                                  >
+                                                                    <StyledComponent
+                                                                      condensed={false}
+                                                                      forwardedComponent={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "attrs": Array [],
+                                                                          "componentStyle": ComponentStyle {
+                                                                            "componentId": "sc-cMljjf",
+                                                                            "isStatic": false,
+                                                                            "lastClassName": "gZZzyn",
+                                                                            "rules": Array [
+                                                                              "
+  padding: ",
+                                                                              [Function],
+                                                                              ";
+  ",
+                                                                              [Function],
+                                                                              ";
+",
+                                                                            ],
+                                                                          },
+                                                                          "displayName": "styled.div",
+                                                                          "foldedComponentIds": Array [],
+                                                                          "render": [Function],
+                                                                          "styledComponentId": "sc-cMljjf",
+                                                                          "target": "div",
+                                                                          "toString": [Function],
+                                                                          "warnTooManyClasses": [Function],
+                                                                          "withComponent": [Function],
+                                                                        }
+                                                                      }
+                                                                      forwardedRef={null}
+                                                                      showTick={false}
+                                                                    >
+                                                                      <div
+                                                                        className="sc-cMljjf gZZzyn"
+                                                                      >
+                                                                        2
+                                                                      </div>
+                                                                    </StyledComponent>
+                                                                  </styled.div>
+                                                                </div>
+                                                              </StyledComponent>
+                                                            </styled.div>
+                                                          </div>
+                                                        </StyledComponent>
+                                                      </styled.div>
+                                                    </li>
+                                                  </StyledComponent>
+                                                </styled.li>
+                                              </div>
+                                            </StyledComponent>
+                                          </styled.div>
+                                        </div>
+                                      </StyledComponent>
+                                    </styled.div>
+                                    <styled.a
+                                      href="#"
+                                      onFocus={[Function]}
+                                    >
+                                      <StyledComponent
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "sc-kgoBCf",
+                                              "isStatic": true,
+                                              "lastClassName": "ccpxKu",
+                                              "rules": Array [
+                                                "
+  height: 0;
+  width: 0;
+  overflow: hidden;
+",
+                                              ],
+                                            },
+                                            "displayName": "styled.a",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "sc-kgoBCf",
+                                            "target": "a",
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
+                                        href="#"
+                                        onFocus={[Function]}
+                                      >
+                                        <a
+                                          className="sc-kgoBCf ccpxKu"
+                                          href="#"
+                                          onFocus={[Function]}
+                                        />
+                                      </StyledComponent>
+                                    </styled.a>
+                                  </div>
+                                </StyledComponent>
+                              </styled.div>
+                              <Styled(styled.div)
+                                className="sc-fBuWsC eySOLS"
+                              >
+                                <StyledComponent
+                                  className="sc-fBuWsC eySOLS"
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "sc-kGXeez",
+                                        "isStatic": true,
+                                        "lastClassName": "fMcQrw",
+                                        "rules": Array [
+                                          "
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  position: fixed;
+  z-index: 10000;
+  overflow-x: hidden;
+  overflow-y: auto;
+",
+                                          "
+  overflow: hidden;
+  z-index: 9999;
+  background: ",
+                                          "rgba(64, 64, 64, 0.4)",
+                                          ";
+",
+                                        ],
+                                      },
+                                      "displayName": "Styled(styled.div)",
+                                      "foldedComponentIds": Array [
+                                        "sc-chPdSV",
+                                      ],
+                                      "render": [Function],
+                                      "styledComponentId": "sc-kGXeez",
+                                      "target": "div",
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={null}
+                                >
+                                  <div
+                                    className="sc-chPdSV sc-fBuWsC eySOLS sc-kGXeez fMcQrw"
+                                  />
+                                </StyledComponent>
+                              </Styled(styled.div)>
+                            </Blocker>
+                          </WindowPopup>
+                        </StyledComponent>
+                      </Styled(WindowPopup)>
+                    </Component>
+                  </div>
+                </StyledComponent>
+              </styled.div>
+            </InteractiveListInt>
+          </InteractiveList>
+        </Responsive>
+      </div>
+    </StyledComponent>
+  </styled.div>
+</DropdownFieldInt>
+`;
+
+exports[`<DropdownField /> should be opened towards the bottom <DropdownField open direction={0}> 1`] = `
+<DropdownFieldInt
+  borderless={true}
+  data={
+    Array [
+      "1",
+      "2",
+    ]
+  }
+  defaultValue="1"
+  direction={0}
+  open={true}
+>
+  <styled.div
+    direction={0}
+    open={true}
+  >
+    <StyledComponent
+      direction={0}
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "sc-jlyJG",
+            "isStatic": true,
+            "lastClassName": "XpIWY",
+            "rules": Array [
+              "
+  position: relative;
+  outline: 0;
+",
+            ],
+          },
+          "displayName": "styled.div",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "sc-jlyJG",
+          "target": "div",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+      open={true}
+    >
+      <div
+        className="sc-jlyJG XpIWY"
+        direction={0}
+        open={true}
+      >
+        <styled.div
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          tabIndex={0}
+        >
+          <StyledComponent
+            forwardedComponent={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "sc-gipzik",
+                  "isStatic": true,
+                  "lastClassName": "bxGTeT",
+                  "rules": Array [
+                    "
+  display: flex;
+",
+                  ],
+                },
+                "displayName": "styled.div",
+                "foldedComponentIds": Array [],
+                "render": [Function],
+                "styledComponentId": "sc-gipzik",
+                "target": "div",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              }
+            }
+            forwardedRef={null}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            tabIndex={0}
+          >
+            <div
+              className="sc-gipzik bxGTeT"
+              onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              tabIndex={0}
+            >
+              <Styled(styled.div)
+                border={0}
+                focused={true}
+                hasValue={true}
+              >
+                <StyledComponent
+                  border={0}
+                  focused={true}
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "sc-csuQGl",
+                        "isStatic": false,
+                        "lastClassName": "kMIMiT",
+                        "rules": Array [
+                          [Function],
+                          "
+  border: 1px solid ",
+                          [Function],
+                          ";
+",
+                        ],
+                      },
+                      "displayName": "Styled(styled.div)",
+                      "foldedComponentIds": Array [
+                        "sc-jzJRlG",
+                      ],
+                      "render": [Function],
+                      "styledComponentId": "sc-csuQGl",
+                      "target": "div",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                  hasValue={true}
+                >
+                  <div
+                    className="sc-jzJRlG sc-csuQGl kMIMiT"
+                  >
+                    <Component
+                      error={false}
+                      focused={true}
+                      hasValue={true}
+                    >
+                      <styled.div>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "sc-gqjmRU",
+                                "isStatic": true,
+                                "lastClassName": "lohXgE",
+                                "rules": Array [
+                                  "
+  flex-grow: 1;
+  display: flex;
+  flex-flow: column-reverse;
+  height: 100%;
+  position: relative;
+  min-width: 0;
+  margin: auto;
+",
+                                ],
+                              },
+                              "displayName": "styled.div",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "sc-gqjmRU",
+                              "target": "div",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <div
+                            className="sc-gqjmRU lohXgE"
+                          >
+                            <styled.div
+                              labelShown={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "sc-Rmtcm",
+                                      "isStatic": false,
+                                      "lastClassName": "iZdMBl",
+                                      "rules": Array [
+                                        "
+  ",
+                                        "
+    ",
+                                        "font-size: 1rem;
+  ",
+                                        "
+    ",
+                                        "line-height: 1.375rem;
+  ",
+                                        "
+    ",
+                                        "
+  ",
+                                        "
+  padding: ",
+                                        [Function],
+                                        ";
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  color: ",
+                                        [Function],
+                                        ";
+  font-family: inherit;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  cursor: ",
+                                        [Function],
+                                        ";
+",
+                                      ],
+                                    },
+                                    "displayName": "styled.div",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "sc-Rmtcm",
+                                    "target": "div",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                labelShown={false}
+                              >
+                                <div
+                                  className="sc-Rmtcm iZdMBl"
+                                >
+                                  <styled.span
+                                    key="1"
+                                  >
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "sc-bRBYWo",
+                                            "isStatic": false,
+                                            "lastClassName": "jelrwS",
+                                            "rules": Array [
+                                              "
+  display: inline-block;
+  line-height: normal;
+  border: 0;
+  color: ",
+                                              [Function],
+                                              ";
+",
+                                            ],
+                                          },
+                                          "displayName": "styled.span",
+                                          "foldedComponentIds": Array [],
+                                          "render": [Function],
+                                          "styledComponentId": "sc-bRBYWo",
+                                          "target": "span",
+                                          "toString": [Function],
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
+                                      }
+                                      forwardedRef={null}
+                                    >
+                                      <span
+                                        className="sc-bRBYWo jelrwS"
+                                      >
+                                        1
+                                      </span>
+                                    </StyledComponent>
+                                  </styled.span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </div>
+                        </StyledComponent>
+                      </styled.div>
+                    </Component>
+                    <Component
+                      hasValue={true}
+                    />
+                    <styled.div>
+                      <StyledComponent
+                        forwardedComponent={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "sc-gZMcBi",
+                              "isStatic": true,
+                              "lastClassName": "YVZuN",
+                              "rules": Array [
+                                "
+  padding: 0 ",
+                                "1rem",
+                                ";
+
+  i {
+    display: block;
+  }
+
+  & + & {
+    padding-left: 0;
+  }
+",
+                              ],
+                            },
+                            "displayName": "styled.div",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "sc-gZMcBi",
+                            "target": "div",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          }
+                        }
+                        forwardedRef={null}
+                      >
+                        <div
+                          className="sc-gZMcBi YVZuN"
+                        >
+                          <Icon
+                            color="rgba(75,78,82,1)"
+                            name="KeyboardArrowUp"
+                            size="22px"
+                          >
+                            <styled.i>
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "sc-htpNat",
+                                      "isStatic": true,
+                                      "lastClassName": "jgiceE",
+                                      "rules": Array [
+                                        "
+  display: inline-block;
+
+  > svg {
+    float: left;
+  }
+",
+                                      ],
+                                    },
+                                    "displayName": "styled.i",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "sc-htpNat",
+                                    "target": "i",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                              >
+                                <i
+                                  className="sc-htpNat jgiceE"
+                                >
+                                  <KeyboardArrowUp
+                                    height="22px"
+                                    style={
+                                      Object {
+                                        "fill": "rgba(75,78,82,1)",
+                                        "stroke": undefined,
+                                      }
+                                    }
+                                    viewBox="0 0 24 24"
+                                    width="22px"
+                                  >
+                                    <svg
+                                      height="22px"
+                                      style={
+                                        Object {
+                                          "fill": "rgba(75,78,82,1)",
+                                          "stroke": undefined,
+                                        }
+                                      }
+                                      viewBox="0 0 24 24"
+                                      width="22px"
+                                    >
+                                      <path
+                                        d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"
+                                      />
+                                    </svg>
+                                  </KeyboardArrowUp>
+                                </i>
+                              </StyledComponent>
+                            </styled.i>
+                          </Icon>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </div>
+                </StyledComponent>
+              </Styled(styled.div)>
+            </div>
+          </StyledComponent>
+        </styled.div>
+        <Responsive
+          render={[Function]}
+        >
+          <InteractiveList
+            autoFocus={true}
+            autoPosition={false}
+            customWrapper={[Function]}
+            data={
+              Array [
+                "1",
+                "2",
+              ]
+            }
+            direction={0}
+            eventTypes={
+              Array [
+                "mousedown",
+                "touchstart",
+              ]
+            }
+            excludeScrollbar={false}
+            indices={
+              Array [
+                0,
+              ]
+            }
+            onChange={[Function]}
+            onClick={[Function]}
+            onClickOutside={[Function]}
+            onKeyDown={[Function]}
+            open={true}
+            outsideClickIgnoreClass="ignore-react-onclickoutside"
+            preventDefault={false}
+            stopPropagation={false}
+          >
+            <InteractiveListInt
+              autoFocus={true}
+              autoPosition={false}
+              customWrapper={[Function]}
+              data={
+                Array [
+                  "1",
+                  "2",
+                ]
+              }
+              direction={0}
+              disableOnClickOutside={[Function]}
+              enableOnClickOutside={[Function]}
+              eventTypes={
+                Array [
+                  "mousedown",
+                  "touchstart",
+                ]
+              }
+              indices={
+                Array [
+                  0,
+                ]
+              }
+              onChange={[Function]}
+              onClick={[Function]}
+              onClickOutside={[Function]}
+              onKeyDown={[Function]}
+              open={true}
+              outsideClickIgnoreClass="ignore-react-onclickoutside"
+              preventDefault={false}
+              stopPropagation={false}
+            >
+              <styled.div
+                autoFocus={true}
+                autoPosition={false}
+                direction={0}
+                disableOnClickOutside={[Function]}
+                enableOnClickOutside={[Function]}
+                eventTypes={
+                  Array [
+                    "mousedown",
+                    "touchstart",
+                  ]
+                }
+                onKeyDown={[Function]}
+                outsideClickIgnoreClass="ignore-react-onclickoutside"
+                preventDefault={false}
+                stopPropagation={false}
+                tabIndex={0}
+              >
+                <StyledComponent
+                  autoFocus={true}
+                  autoPosition={false}
+                  direction={0}
+                  disableOnClickOutside={[Function]}
+                  enableOnClickOutside={[Function]}
+                  eventTypes={
+                    Array [
+                      "mousedown",
+                      "touchstart",
+                    ]
+                  }
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "sc-hSdWYo",
+                        "isStatic": true,
+                        "lastClassName": "bUjOem",
+                        "rules": Array [
+                          "
+  position: relative;
+  outline: none;
+",
+                        ],
+                      },
+                      "displayName": "styled.div",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "sc-hSdWYo",
+                      "target": "div",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={[Function]}
+                  onKeyDown={[Function]}
+                  outsideClickIgnoreClass="ignore-react-onclickoutside"
+                  preventDefault={false}
+                  stopPropagation={false}
+                  tabIndex={0}
+                >
+                  <div
+                    autoFocus={true}
+                    className="sc-hSdWYo bUjOem"
+                    direction={0}
+                    onKeyDown={[Function]}
+                    tabIndex={0}
+                  >
+                    <Component
+                      border={1}
+                      direction={0}
+                      onClick={[Function]}
+                      open={true}
+                    >
+                      <Styled(WindowPopup)
+                        label={<ForwardRef />}
+                        onClose={[Function]}
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "sc-fBuWsC",
+                                "isStatic": true,
+                                "lastClassName": "eySOLS",
+                                "rules": Array [
+                                  "
+  border: 2em solid transparent;
+",
+                                ],
+                              },
+                              "displayName": "Styled(WindowPopup)",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "sc-fBuWsC",
+                              "target": [Function],
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          label={<ForwardRef />}
+                          onClose={[Function]}
+                        >
+                          <WindowPopup
+                            className="sc-fBuWsC eySOLS"
+                            label={<ForwardRef />}
+                            onClose={[Function]}
+                          >
+                            <Blocker
+                              className="sc-fBuWsC eySOLS"
+                              onClose={[Function]}
+                            >
+                              <styled.div
+                                className="sc-fBuWsC eySOLS"
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                              >
+                                <StyledComponent
+                                  className="sc-fBuWsC eySOLS"
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "sc-chPdSV",
+                                        "isStatic": true,
+                                        "lastClassName": "juaCGL",
+                                        "rules": Array [
+                                          "
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  position: fixed;
+  z-index: 10000;
+  overflow-x: hidden;
+  overflow-y: auto;
+",
+                                        ],
+                                      },
+                                      "displayName": "styled.div",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "sc-chPdSV",
+                                      "target": "div",
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={[Function]}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                >
+                                  <div
+                                    className="sc-fBuWsC eySOLS sc-chPdSV juaCGL"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                  >
+                                    <styled.a
+                                      href="#"
+                                      onFocus={[Function]}
+                                    >
+                                      <StyledComponent
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "sc-kgoBCf",
+                                              "isStatic": true,
+                                              "lastClassName": "ccpxKu",
+                                              "rules": Array [
+                                                "
+  height: 0;
+  width: 0;
+  overflow: hidden;
+",
+                                              ],
+                                            },
+                                            "displayName": "styled.a",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "sc-kgoBCf",
+                                            "target": "a",
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
+                                        href="#"
+                                        onFocus={[Function]}
+                                      >
+                                        <a
+                                          className="sc-kgoBCf ccpxKu"
+                                          href="#"
+                                          onFocus={[Function]}
+                                        />
+                                      </StyledComponent>
+                                    </styled.a>
+                                    <styled.div
+                                      tabIndex={0}
+                                    >
+                                      <StyledComponent
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "sc-dxgOiQ",
+                                              "isStatic": false,
+                                              "lastClassName": "dyHuYR",
+                                              "rules": Array [
+                                                "
+  padding: ",
+                                                "1rem",
+                                                ";
+  box-sizing: border-box;
+  height: 100%;
+  overflow-y: auto;
+  background: ",
+                                                [Function],
+                                                ";
+",
+                                              ],
+                                            },
+                                            "displayName": "styled.div",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "sc-dxgOiQ",
+                                            "target": "div",
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
+                                        tabIndex={0}
+                                      >
+                                        <div
+                                          className="sc-dxgOiQ dyHuYR"
+                                          tabIndex={0}
+                                        >
+                                          <styled.div>
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-jKJlTe",
+                                                    "isStatic": false,
+                                                    "lastClassName": "cKsVkt",
+                                                    "rules": Array [
+                                                      "
+  ",
+                                                      "
+    ",
+                                                      "font-size: 0.875rem;
+  ",
+                                                      "
+    ",
+                                                      "line-height: 1.125rem;
+  ",
+                                                      "
+    ",
+                                                      "
+  ",
+                                                      "
+
+  color: ",
+                                                      [Function],
+                                                      ";
+  padding-bottom: ",
+                                                      "1rem",
+                                                      ";
+  min-height: ",
+                                                      "0.875rem",
+                                                      ";
+",
+                                                    ],
+                                                  },
+                                                  "displayName": "styled.div",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-jKJlTe",
+                                                  "target": "div",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                            >
+                                              <div
+                                                className="sc-jKJlTe cKsVkt"
+                                              >
+                                                <styled.div>
+                                                  <StyledComponent
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-jhAzac",
+                                                          "isStatic": true,
+                                                          "lastClassName": "gwtcyj",
+                                                          "rules": Array [
+                                                            "
+  padding-left: ",
+                                                            "1rem",
+                                                            ";
+",
+                                                          ],
+                                                        },
+                                                        "displayName": "styled.div",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-jhAzac",
+                                                        "target": "div",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                  >
+                                                    <div
+                                                      className="sc-jhAzac gwtcyj"
+                                                    />
+                                                  </StyledComponent>
+                                                </styled.div>
+                                              </div>
+                                            </StyledComponent>
+                                          </styled.div>
+                                          <CloseButton
+                                            onClick={[Function]}
+                                          >
+                                            <styled.a
+                                              onClick={[Function]}
+                                            >
+                                              <StyledComponent
+                                                forwardedComponent={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "attrs": Array [],
+                                                    "componentStyle": ComponentStyle {
+                                                      "componentId": "sc-kpOJdX",
+                                                      "isStatic": true,
+                                                      "lastClassName": "kxReIc",
+                                                      "rules": Array [
+                                                        "
+  ",
+                                                        "
+    ",
+                                                        "font-size: 1rem;
+  ",
+                                                        "
+    ",
+                                                        "line-height: 1.375rem;
+  ",
+                                                        "
+    ",
+                                                        "
+  ",
+                                                        "
+
+  position: absolute;
+  top: ",
+                                                        "1rem",
+                                                        ";
+  right: ",
+                                                        "1rem",
+                                                        ";
+  background-color: ",
+                                                        "rgba(255, 255, 255, 0)",
+                                                        ";
+  padding: 0;
+  border: none;
+  align-self: start;
+  cursor: pointer;
+  color: ",
+                                                        "rgba(0,0,0,1)",
+                                                        ";
+  opacity: 0.2;
+  transition: opacity 0.2s ease-out;
+
+  &:hover {
+    opacity: 0.5;
+  }
+",
+                                                      ],
+                                                    },
+                                                    "displayName": "styled.a",
+                                                    "foldedComponentIds": Array [],
+                                                    "render": [Function],
+                                                    "styledComponentId": "sc-kpOJdX",
+                                                    "target": "a",
+                                                    "toString": [Function],
+                                                    "warnTooManyClasses": [Function],
+                                                    "withComponent": [Function],
+                                                  }
+                                                }
+                                                forwardedRef={null}
+                                                onClick={[Function]}
+                                              >
+                                                <a
+                                                  className="sc-kpOJdX kxReIc"
+                                                  onClick={[Function]}
+                                                >
+                                                  <Icon
+                                                    name="Close"
+                                                    size={1.1}
+                                                  >
+                                                    <styled.i>
+                                                      <StyledComponent
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "sc-htpNat",
+                                                              "isStatic": true,
+                                                              "lastClassName": "jgiceE",
+                                                              "rules": Array [
+                                                                "
+  display: inline-block;
+
+  > svg {
+    float: left;
+  }
+",
+                                                              ],
+                                                            },
+                                                            "displayName": "styled.i",
+                                                            "foldedComponentIds": Array [],
+                                                            "render": [Function],
+                                                            "styledComponentId": "sc-htpNat",
+                                                            "target": "i",
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
+                                                          }
+                                                        }
+                                                        forwardedRef={null}
+                                                      >
+                                                        <i
+                                                          className="sc-htpNat jgiceE"
+                                                        >
+                                                          <Close
+                                                            height="1.1em"
+                                                            style={
+                                                              Object {
+                                                                "fill": "currentColor",
+                                                                "stroke": undefined,
+                                                              }
+                                                            }
+                                                            viewBox="0 0 24 24"
+                                                            width="1.1em"
+                                                          >
+                                                            <svg
+                                                              height="1.1em"
+                                                              style={
+                                                                Object {
+                                                                  "fill": "currentColor",
+                                                                  "stroke": undefined,
+                                                                }
+                                                              }
+                                                              viewBox="0 0 24 24"
+                                                              width="1.1em"
+                                                            >
+                                                              <path
+                                                                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                              />
+                                                            </svg>
+                                                          </Close>
+                                                        </i>
+                                                      </StyledComponent>
+                                                    </styled.i>
+                                                  </Icon>
+                                                </a>
+                                              </StyledComponent>
+                                            </styled.a>
+                                          </CloseButton>
+                                          <styled.div>
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-ckVGcZ",
+                                                    "isStatic": true,
+                                                    "lastClassName": "fvuixH",
+                                                    "rules": Array [
+                                                      "
+  box-sizing: border-box;
+  margin: 0;
+",
+                                                    ],
+                                                  },
+                                                  "displayName": "styled.div",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-ckVGcZ",
+                                                  "target": "div",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                            >
+                                              <div
+                                                className="sc-ckVGcZ fvuixH"
+                                              >
+                                                <styled.li
+                                                  hovered={false}
+                                                  key="1-0"
+                                                  onClick={[Function]}
+                                                  onMouseMove={[Function]}
+                                                  selected={true}
+                                                >
+                                                  <StyledComponent
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-cvbbAY",
+                                                          "isStatic": false,
+                                                          "lastClassName": "eAHqky",
+                                                          "rules": Array [
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "displayName": "styled.li",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-cvbbAY",
+                                                        "target": "li",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={[Function]}
+                                                    hovered={false}
+                                                    onClick={[Function]}
+                                                    onMouseMove={[Function]}
+                                                    selected={true}
+                                                  >
+                                                    <li
+                                                      className="sc-cvbbAY eAHqky"
+                                                      onClick={[Function]}
+                                                      onMouseMove={[Function]}
+                                                      selected={true}
+                                                    >
+                                                      <styled.div>
+                                                        <StyledComponent
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-jWBwVP",
+                                                                "isStatic": true,
+                                                                "lastClassName": "jZcPPp",
+                                                                "rules": Array [
+                                                                  "
+  display: flex;
+  align-items: center;
+",
+                                                                ],
+                                                              },
+                                                              "displayName": "styled.div",
+                                                              "foldedComponentIds": Array [],
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-jWBwVP",
+                                                              "target": "div",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                        >
+                                                          <div
+                                                            className="sc-jWBwVP jZcPPp"
+                                                          >
+                                                            <styled.div>
+                                                              <StyledComponent
+                                                                forwardedComponent={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "attrs": Array [],
+                                                                    "componentStyle": ComponentStyle {
+                                                                      "componentId": "sc-brqgnP",
+                                                                      "isStatic": true,
+                                                                      "lastClassName": "jgYEci",
+                                                                      "rules": Array [
+                                                                        "
+  flex-grow: 1;
+",
+                                                                      ],
+                                                                    },
+                                                                    "displayName": "styled.div",
+                                                                    "foldedComponentIds": Array [],
+                                                                    "render": [Function],
+                                                                    "styledComponentId": "sc-brqgnP",
+                                                                    "target": "div",
+                                                                    "toString": [Function],
+                                                                    "warnTooManyClasses": [Function],
+                                                                    "withComponent": [Function],
+                                                                  }
+                                                                }
+                                                                forwardedRef={null}
+                                                              >
+                                                                <div
+                                                                  className="sc-brqgnP jgYEci"
+                                                                >
+                                                                  <styled.div
+                                                                    condensed={false}
+                                                                    showTick={false}
+                                                                  >
+                                                                    <StyledComponent
+                                                                      condensed={false}
+                                                                      forwardedComponent={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "attrs": Array [],
+                                                                          "componentStyle": ComponentStyle {
+                                                                            "componentId": "sc-cMljjf",
+                                                                            "isStatic": false,
+                                                                            "lastClassName": "gZZzyn",
+                                                                            "rules": Array [
+                                                                              "
+  padding: ",
+                                                                              [Function],
+                                                                              ";
+  ",
+                                                                              [Function],
+                                                                              ";
+",
+                                                                            ],
+                                                                          },
+                                                                          "displayName": "styled.div",
+                                                                          "foldedComponentIds": Array [],
+                                                                          "render": [Function],
+                                                                          "styledComponentId": "sc-cMljjf",
+                                                                          "target": "div",
+                                                                          "toString": [Function],
+                                                                          "warnTooManyClasses": [Function],
+                                                                          "withComponent": [Function],
+                                                                        }
+                                                                      }
+                                                                      forwardedRef={null}
+                                                                      showTick={false}
+                                                                    >
+                                                                      <div
+                                                                        className="sc-cMljjf gZZzyn"
+                                                                      >
+                                                                        1
+                                                                      </div>
+                                                                    </StyledComponent>
+                                                                  </styled.div>
+                                                                </div>
+                                                              </StyledComponent>
+                                                            </styled.div>
+                                                          </div>
+                                                        </StyledComponent>
+                                                      </styled.div>
+                                                    </li>
+                                                  </StyledComponent>
+                                                </styled.li>
+                                                <styled.li
+                                                  hovered={false}
+                                                  key="2-1"
+                                                  onClick={[Function]}
+                                                  onMouseMove={[Function]}
+                                                  selected={false}
+                                                >
+                                                  <StyledComponent
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-cvbbAY",
+                                                          "isStatic": false,
+                                                          "lastClassName": "eAHqky",
+                                                          "rules": Array [
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "displayName": "styled.li",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-cvbbAY",
+                                                        "target": "li",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={[Function]}
+                                                    hovered={false}
+                                                    onClick={[Function]}
+                                                    onMouseMove={[Function]}
+                                                    selected={false}
+                                                  >
+                                                    <li
+                                                      className="sc-cvbbAY eAHqky"
+                                                      onClick={[Function]}
+                                                      onMouseMove={[Function]}
+                                                      selected={false}
+                                                    >
+                                                      <styled.div>
+                                                        <StyledComponent
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-jWBwVP",
+                                                                "isStatic": true,
+                                                                "lastClassName": "jZcPPp",
+                                                                "rules": Array [
+                                                                  "
+  display: flex;
+  align-items: center;
+",
+                                                                ],
+                                                              },
+                                                              "displayName": "styled.div",
+                                                              "foldedComponentIds": Array [],
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-jWBwVP",
+                                                              "target": "div",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                        >
+                                                          <div
+                                                            className="sc-jWBwVP jZcPPp"
+                                                          >
+                                                            <styled.div>
+                                                              <StyledComponent
+                                                                forwardedComponent={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "attrs": Array [],
+                                                                    "componentStyle": ComponentStyle {
+                                                                      "componentId": "sc-brqgnP",
+                                                                      "isStatic": true,
+                                                                      "lastClassName": "jgYEci",
+                                                                      "rules": Array [
+                                                                        "
+  flex-grow: 1;
+",
+                                                                      ],
+                                                                    },
+                                                                    "displayName": "styled.div",
+                                                                    "foldedComponentIds": Array [],
+                                                                    "render": [Function],
+                                                                    "styledComponentId": "sc-brqgnP",
+                                                                    "target": "div",
+                                                                    "toString": [Function],
+                                                                    "warnTooManyClasses": [Function],
+                                                                    "withComponent": [Function],
+                                                                  }
+                                                                }
+                                                                forwardedRef={null}
+                                                              >
+                                                                <div
+                                                                  className="sc-brqgnP jgYEci"
+                                                                >
+                                                                  <styled.div
+                                                                    condensed={false}
+                                                                    showTick={false}
+                                                                  >
+                                                                    <StyledComponent
+                                                                      condensed={false}
+                                                                      forwardedComponent={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "attrs": Array [],
+                                                                          "componentStyle": ComponentStyle {
+                                                                            "componentId": "sc-cMljjf",
+                                                                            "isStatic": false,
+                                                                            "lastClassName": "gZZzyn",
+                                                                            "rules": Array [
+                                                                              "
+  padding: ",
+                                                                              [Function],
+                                                                              ";
+  ",
+                                                                              [Function],
+                                                                              ";
+",
+                                                                            ],
+                                                                          },
+                                                                          "displayName": "styled.div",
+                                                                          "foldedComponentIds": Array [],
+                                                                          "render": [Function],
+                                                                          "styledComponentId": "sc-cMljjf",
+                                                                          "target": "div",
+                                                                          "toString": [Function],
+                                                                          "warnTooManyClasses": [Function],
+                                                                          "withComponent": [Function],
+                                                                        }
+                                                                      }
+                                                                      forwardedRef={null}
+                                                                      showTick={false}
+                                                                    >
+                                                                      <div
+                                                                        className="sc-cMljjf gZZzyn"
+                                                                      >
+                                                                        2
+                                                                      </div>
+                                                                    </StyledComponent>
+                                                                  </styled.div>
+                                                                </div>
+                                                              </StyledComponent>
+                                                            </styled.div>
+                                                          </div>
+                                                        </StyledComponent>
+                                                      </styled.div>
+                                                    </li>
+                                                  </StyledComponent>
+                                                </styled.li>
+                                              </div>
+                                            </StyledComponent>
+                                          </styled.div>
+                                        </div>
+                                      </StyledComponent>
+                                    </styled.div>
+                                    <styled.a
+                                      href="#"
+                                      onFocus={[Function]}
+                                    >
+                                      <StyledComponent
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "sc-kgoBCf",
+                                              "isStatic": true,
+                                              "lastClassName": "ccpxKu",
+                                              "rules": Array [
+                                                "
+  height: 0;
+  width: 0;
+  overflow: hidden;
+",
+                                              ],
+                                            },
+                                            "displayName": "styled.a",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "sc-kgoBCf",
+                                            "target": "a",
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
+                                        href="#"
+                                        onFocus={[Function]}
+                                      >
+                                        <a
+                                          className="sc-kgoBCf ccpxKu"
+                                          href="#"
+                                          onFocus={[Function]}
+                                        />
+                                      </StyledComponent>
+                                    </styled.a>
+                                  </div>
+                                </StyledComponent>
+                              </styled.div>
+                              <Styled(styled.div)
+                                className="sc-fBuWsC eySOLS"
+                              >
+                                <StyledComponent
+                                  className="sc-fBuWsC eySOLS"
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "sc-kGXeez",
+                                        "isStatic": true,
+                                        "lastClassName": "fMcQrw",
+                                        "rules": Array [
+                                          "
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  position: fixed;
+  z-index: 10000;
+  overflow-x: hidden;
+  overflow-y: auto;
+",
+                                          "
+  overflow: hidden;
+  z-index: 9999;
+  background: ",
+                                          "rgba(64, 64, 64, 0.4)",
+                                          ";
+",
+                                        ],
+                                      },
+                                      "displayName": "Styled(styled.div)",
+                                      "foldedComponentIds": Array [
+                                        "sc-chPdSV",
+                                      ],
+                                      "render": [Function],
+                                      "styledComponentId": "sc-kGXeez",
+                                      "target": "div",
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={null}
+                                >
+                                  <div
+                                    className="sc-chPdSV sc-fBuWsC eySOLS sc-kGXeez fMcQrw"
+                                  />
+                                </StyledComponent>
+                              </Styled(styled.div)>
+                            </Blocker>
+                          </WindowPopup>
+                        </StyledComponent>
+                      </Styled(WindowPopup)>
+                    </Component>
+                  </div>
+                </StyledComponent>
+              </styled.div>
+            </InteractiveListInt>
+          </InteractiveList>
+        </Responsive>
+      </div>
+    </StyledComponent>
+  </styled.div>
+</DropdownFieldInt>
+`;
+
+exports[`<DropdownField /> should be opened towards the top <DropdownField open direction={1}> 1`] = `
+<DropdownFieldInt
+  borderless={true}
+  data={
+    Array [
+      "1",
+      "2",
+    ]
+  }
+  defaultValue="1"
+  direction={1}
+  open={true}
+>
+  <styled.div
+    direction={1}
+    open={true}
+  >
+    <StyledComponent
+      direction={1}
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "sc-jlyJG",
+            "isStatic": true,
+            "lastClassName": "XpIWY",
+            "rules": Array [
+              "
+  position: relative;
+  outline: 0;
+",
+            ],
+          },
+          "displayName": "styled.div",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "sc-jlyJG",
+          "target": "div",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+      open={true}
+    >
+      <div
+        className="sc-jlyJG XpIWY"
+        direction={1}
+        open={true}
+      >
+        <styled.div
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          tabIndex={0}
+        >
+          <StyledComponent
+            forwardedComponent={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "sc-gipzik",
+                  "isStatic": true,
+                  "lastClassName": "bxGTeT",
+                  "rules": Array [
+                    "
+  display: flex;
+",
+                  ],
+                },
+                "displayName": "styled.div",
+                "foldedComponentIds": Array [],
+                "render": [Function],
+                "styledComponentId": "sc-gipzik",
+                "target": "div",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              }
+            }
+            forwardedRef={null}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            tabIndex={0}
+          >
+            <div
+              className="sc-gipzik bxGTeT"
+              onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              tabIndex={0}
+            >
+              <Styled(styled.div)
+                border={0}
+                focused={true}
+                hasValue={true}
+              >
+                <StyledComponent
+                  border={0}
+                  focused={true}
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "sc-csuQGl",
+                        "isStatic": false,
+                        "lastClassName": "kMIMiT",
+                        "rules": Array [
+                          [Function],
+                          "
+  border: 1px solid ",
+                          [Function],
+                          ";
+",
+                        ],
+                      },
+                      "displayName": "Styled(styled.div)",
+                      "foldedComponentIds": Array [
+                        "sc-jzJRlG",
+                      ],
+                      "render": [Function],
+                      "styledComponentId": "sc-csuQGl",
+                      "target": "div",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                  hasValue={true}
+                >
+                  <div
+                    className="sc-jzJRlG sc-csuQGl kMIMiT"
+                  >
+                    <Component
+                      error={false}
+                      focused={true}
+                      hasValue={true}
+                    >
+                      <styled.div>
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "sc-gqjmRU",
+                                "isStatic": true,
+                                "lastClassName": "lohXgE",
+                                "rules": Array [
+                                  "
+  flex-grow: 1;
+  display: flex;
+  flex-flow: column-reverse;
+  height: 100%;
+  position: relative;
+  min-width: 0;
+  margin: auto;
+",
+                                ],
+                              },
+                              "displayName": "styled.div",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "sc-gqjmRU",
+                              "target": "div",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <div
+                            className="sc-gqjmRU lohXgE"
+                          >
+                            <styled.div
+                              labelShown={false}
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "sc-Rmtcm",
+                                      "isStatic": false,
+                                      "lastClassName": "iZdMBl",
+                                      "rules": Array [
+                                        "
+  ",
+                                        "
+    ",
+                                        "font-size: 1rem;
+  ",
+                                        "
+    ",
+                                        "line-height: 1.375rem;
+  ",
+                                        "
+    ",
+                                        "
+  ",
+                                        "
+  padding: ",
+                                        [Function],
+                                        ";
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  color: ",
+                                        [Function],
+                                        ";
+  font-family: inherit;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  cursor: ",
+                                        [Function],
+                                        ";
+",
+                                      ],
+                                    },
+                                    "displayName": "styled.div",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "sc-Rmtcm",
+                                    "target": "div",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                                labelShown={false}
+                              >
+                                <div
+                                  className="sc-Rmtcm iZdMBl"
+                                >
+                                  <styled.span
+                                    key="1"
+                                  >
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "sc-bRBYWo",
+                                            "isStatic": false,
+                                            "lastClassName": "jelrwS",
+                                            "rules": Array [
+                                              "
+  display: inline-block;
+  line-height: normal;
+  border: 0;
+  color: ",
+                                              [Function],
+                                              ";
+",
+                                            ],
+                                          },
+                                          "displayName": "styled.span",
+                                          "foldedComponentIds": Array [],
+                                          "render": [Function],
+                                          "styledComponentId": "sc-bRBYWo",
+                                          "target": "span",
+                                          "toString": [Function],
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
+                                      }
+                                      forwardedRef={null}
+                                    >
+                                      <span
+                                        className="sc-bRBYWo jelrwS"
+                                      >
+                                        1
+                                      </span>
+                                    </StyledComponent>
+                                  </styled.span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </div>
+                        </StyledComponent>
+                      </styled.div>
+                    </Component>
+                    <Component
+                      hasValue={true}
+                    />
+                    <styled.div>
+                      <StyledComponent
+                        forwardedComponent={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "sc-gZMcBi",
+                              "isStatic": true,
+                              "lastClassName": "YVZuN",
+                              "rules": Array [
+                                "
+  padding: 0 ",
+                                "1rem",
+                                ";
+
+  i {
+    display: block;
+  }
+
+  & + & {
+    padding-left: 0;
+  }
+",
+                              ],
+                            },
+                            "displayName": "styled.div",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "sc-gZMcBi",
+                            "target": "div",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          }
+                        }
+                        forwardedRef={null}
+                      >
+                        <div
+                          className="sc-gZMcBi YVZuN"
+                        >
+                          <Icon
+                            color="rgba(75,78,82,1)"
+                            name="KeyboardArrowUp"
+                            size="22px"
+                          >
+                            <styled.i>
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "sc-htpNat",
+                                      "isStatic": true,
+                                      "lastClassName": "jgiceE",
+                                      "rules": Array [
+                                        "
+  display: inline-block;
+
+  > svg {
+    float: left;
+  }
+",
+                                      ],
+                                    },
+                                    "displayName": "styled.i",
+                                    "foldedComponentIds": Array [],
+                                    "render": [Function],
+                                    "styledComponentId": "sc-htpNat",
+                                    "target": "i",
+                                    "toString": [Function],
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={null}
+                              >
+                                <i
+                                  className="sc-htpNat jgiceE"
+                                >
+                                  <KeyboardArrowUp
+                                    height="22px"
+                                    style={
+                                      Object {
+                                        "fill": "rgba(75,78,82,1)",
+                                        "stroke": undefined,
+                                      }
+                                    }
+                                    viewBox="0 0 24 24"
+                                    width="22px"
+                                  >
+                                    <svg
+                                      height="22px"
+                                      style={
+                                        Object {
+                                          "fill": "rgba(75,78,82,1)",
+                                          "stroke": undefined,
+                                        }
+                                      }
+                                      viewBox="0 0 24 24"
+                                      width="22px"
+                                    >
+                                      <path
+                                        d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"
+                                      />
+                                    </svg>
+                                  </KeyboardArrowUp>
+                                </i>
+                              </StyledComponent>
+                            </styled.i>
+                          </Icon>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </div>
+                </StyledComponent>
+              </Styled(styled.div)>
+            </div>
+          </StyledComponent>
+        </styled.div>
+        <Responsive
+          render={[Function]}
+        >
+          <InteractiveList
+            autoFocus={true}
+            autoPosition={false}
+            customWrapper={[Function]}
+            data={
+              Array [
+                "1",
+                "2",
+              ]
+            }
+            direction={1}
+            eventTypes={
+              Array [
+                "mousedown",
+                "touchstart",
+              ]
+            }
+            excludeScrollbar={false}
+            indices={
+              Array [
+                0,
+              ]
+            }
+            onChange={[Function]}
+            onClick={[Function]}
+            onClickOutside={[Function]}
+            onKeyDown={[Function]}
+            open={true}
+            outsideClickIgnoreClass="ignore-react-onclickoutside"
+            preventDefault={false}
+            stopPropagation={false}
+          >
+            <InteractiveListInt
+              autoFocus={true}
+              autoPosition={false}
+              customWrapper={[Function]}
+              data={
+                Array [
+                  "1",
+                  "2",
+                ]
+              }
+              direction={1}
+              disableOnClickOutside={[Function]}
+              enableOnClickOutside={[Function]}
+              eventTypes={
+                Array [
+                  "mousedown",
+                  "touchstart",
+                ]
+              }
+              indices={
+                Array [
+                  0,
+                ]
+              }
+              onChange={[Function]}
+              onClick={[Function]}
+              onClickOutside={[Function]}
+              onKeyDown={[Function]}
+              open={true}
+              outsideClickIgnoreClass="ignore-react-onclickoutside"
+              preventDefault={false}
+              stopPropagation={false}
+            >
+              <styled.div
+                autoFocus={true}
+                autoPosition={false}
+                direction={1}
+                disableOnClickOutside={[Function]}
+                enableOnClickOutside={[Function]}
+                eventTypes={
+                  Array [
+                    "mousedown",
+                    "touchstart",
+                  ]
+                }
+                onKeyDown={[Function]}
+                outsideClickIgnoreClass="ignore-react-onclickoutside"
+                preventDefault={false}
+                stopPropagation={false}
+                tabIndex={0}
+              >
+                <StyledComponent
+                  autoFocus={true}
+                  autoPosition={false}
+                  direction={1}
+                  disableOnClickOutside={[Function]}
+                  enableOnClickOutside={[Function]}
+                  eventTypes={
+                    Array [
+                      "mousedown",
+                      "touchstart",
+                    ]
+                  }
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "sc-hSdWYo",
+                        "isStatic": true,
+                        "lastClassName": "bUjOem",
+                        "rules": Array [
+                          "
+  position: relative;
+  outline: none;
+",
+                        ],
+                      },
+                      "displayName": "styled.div",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "sc-hSdWYo",
+                      "target": "div",
+                      "toString": [Function],
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={[Function]}
+                  onKeyDown={[Function]}
+                  outsideClickIgnoreClass="ignore-react-onclickoutside"
+                  preventDefault={false}
+                  stopPropagation={false}
+                  tabIndex={0}
+                >
+                  <div
+                    autoFocus={true}
+                    className="sc-hSdWYo bUjOem"
+                    direction={1}
+                    onKeyDown={[Function]}
+                    tabIndex={0}
+                  >
+                    <Component
+                      border={1}
+                      direction={1}
+                      onClick={[Function]}
+                      open={true}
+                    >
+                      <Styled(WindowPopup)
+                        label={<ForwardRef />}
+                        onClose={[Function]}
+                      >
+                        <StyledComponent
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "sc-fBuWsC",
+                                "isStatic": true,
+                                "lastClassName": "eySOLS",
+                                "rules": Array [
+                                  "
+  border: 2em solid transparent;
+",
+                                ],
+                              },
+                              "displayName": "Styled(WindowPopup)",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "sc-fBuWsC",
+                              "target": [Function],
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          label={<ForwardRef />}
+                          onClose={[Function]}
+                        >
+                          <WindowPopup
+                            className="sc-fBuWsC eySOLS"
+                            label={<ForwardRef />}
+                            onClose={[Function]}
+                          >
+                            <Blocker
+                              className="sc-fBuWsC eySOLS"
+                              onClose={[Function]}
+                            >
+                              <styled.div
+                                className="sc-fBuWsC eySOLS"
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                              >
+                                <StyledComponent
+                                  className="sc-fBuWsC eySOLS"
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "sc-chPdSV",
+                                        "isStatic": true,
+                                        "lastClassName": "juaCGL",
+                                        "rules": Array [
+                                          "
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  position: fixed;
+  z-index: 10000;
+  overflow-x: hidden;
+  overflow-y: auto;
+",
+                                        ],
+                                      },
+                                      "displayName": "styled.div",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "sc-chPdSV",
+                                      "target": "div",
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={[Function]}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                >
+                                  <div
+                                    className="sc-fBuWsC eySOLS sc-chPdSV juaCGL"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                  >
+                                    <styled.a
+                                      href="#"
+                                      onFocus={[Function]}
+                                    >
+                                      <StyledComponent
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "sc-kgoBCf",
+                                              "isStatic": true,
+                                              "lastClassName": "ccpxKu",
+                                              "rules": Array [
+                                                "
+  height: 0;
+  width: 0;
+  overflow: hidden;
+",
+                                              ],
+                                            },
+                                            "displayName": "styled.a",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "sc-kgoBCf",
+                                            "target": "a",
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
+                                        href="#"
+                                        onFocus={[Function]}
+                                      >
+                                        <a
+                                          className="sc-kgoBCf ccpxKu"
+                                          href="#"
+                                          onFocus={[Function]}
+                                        />
+                                      </StyledComponent>
+                                    </styled.a>
+                                    <styled.div
+                                      tabIndex={0}
+                                    >
+                                      <StyledComponent
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "sc-dxgOiQ",
+                                              "isStatic": false,
+                                              "lastClassName": "dyHuYR",
+                                              "rules": Array [
+                                                "
+  padding: ",
+                                                "1rem",
+                                                ";
+  box-sizing: border-box;
+  height: 100%;
+  overflow-y: auto;
+  background: ",
+                                                [Function],
+                                                ";
+",
+                                              ],
+                                            },
+                                            "displayName": "styled.div",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "sc-dxgOiQ",
+                                            "target": "div",
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
+                                        tabIndex={0}
+                                      >
+                                        <div
+                                          className="sc-dxgOiQ dyHuYR"
+                                          tabIndex={0}
+                                        >
+                                          <styled.div>
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-jKJlTe",
+                                                    "isStatic": false,
+                                                    "lastClassName": "cKsVkt",
+                                                    "rules": Array [
+                                                      "
+  ",
+                                                      "
+    ",
+                                                      "font-size: 0.875rem;
+  ",
+                                                      "
+    ",
+                                                      "line-height: 1.125rem;
+  ",
+                                                      "
+    ",
+                                                      "
+  ",
+                                                      "
+
+  color: ",
+                                                      [Function],
+                                                      ";
+  padding-bottom: ",
+                                                      "1rem",
+                                                      ";
+  min-height: ",
+                                                      "0.875rem",
+                                                      ";
+",
+                                                    ],
+                                                  },
+                                                  "displayName": "styled.div",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-jKJlTe",
+                                                  "target": "div",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                            >
+                                              <div
+                                                className="sc-jKJlTe cKsVkt"
+                                              >
+                                                <styled.div>
+                                                  <StyledComponent
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-jhAzac",
+                                                          "isStatic": true,
+                                                          "lastClassName": "gwtcyj",
+                                                          "rules": Array [
+                                                            "
+  padding-left: ",
+                                                            "1rem",
+                                                            ";
+",
+                                                          ],
+                                                        },
+                                                        "displayName": "styled.div",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-jhAzac",
+                                                        "target": "div",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={null}
+                                                  >
+                                                    <div
+                                                      className="sc-jhAzac gwtcyj"
+                                                    />
+                                                  </StyledComponent>
+                                                </styled.div>
+                                              </div>
+                                            </StyledComponent>
+                                          </styled.div>
+                                          <CloseButton
+                                            onClick={[Function]}
+                                          >
+                                            <styled.a
+                                              onClick={[Function]}
+                                            >
+                                              <StyledComponent
+                                                forwardedComponent={
+                                                  Object {
+                                                    "$$typeof": Symbol(react.forward_ref),
+                                                    "attrs": Array [],
+                                                    "componentStyle": ComponentStyle {
+                                                      "componentId": "sc-kpOJdX",
+                                                      "isStatic": true,
+                                                      "lastClassName": "kxReIc",
+                                                      "rules": Array [
+                                                        "
+  ",
+                                                        "
+    ",
+                                                        "font-size: 1rem;
+  ",
+                                                        "
+    ",
+                                                        "line-height: 1.375rem;
+  ",
+                                                        "
+    ",
+                                                        "
+  ",
+                                                        "
+
+  position: absolute;
+  top: ",
+                                                        "1rem",
+                                                        ";
+  right: ",
+                                                        "1rem",
+                                                        ";
+  background-color: ",
+                                                        "rgba(255, 255, 255, 0)",
+                                                        ";
+  padding: 0;
+  border: none;
+  align-self: start;
+  cursor: pointer;
+  color: ",
+                                                        "rgba(0,0,0,1)",
+                                                        ";
+  opacity: 0.2;
+  transition: opacity 0.2s ease-out;
+
+  &:hover {
+    opacity: 0.5;
+  }
+",
+                                                      ],
+                                                    },
+                                                    "displayName": "styled.a",
+                                                    "foldedComponentIds": Array [],
+                                                    "render": [Function],
+                                                    "styledComponentId": "sc-kpOJdX",
+                                                    "target": "a",
+                                                    "toString": [Function],
+                                                    "warnTooManyClasses": [Function],
+                                                    "withComponent": [Function],
+                                                  }
+                                                }
+                                                forwardedRef={null}
+                                                onClick={[Function]}
+                                              >
+                                                <a
+                                                  className="sc-kpOJdX kxReIc"
+                                                  onClick={[Function]}
+                                                >
+                                                  <Icon
+                                                    name="Close"
+                                                    size={1.1}
+                                                  >
+                                                    <styled.i>
+                                                      <StyledComponent
+                                                        forwardedComponent={
+                                                          Object {
+                                                            "$$typeof": Symbol(react.forward_ref),
+                                                            "attrs": Array [],
+                                                            "componentStyle": ComponentStyle {
+                                                              "componentId": "sc-htpNat",
+                                                              "isStatic": true,
+                                                              "lastClassName": "jgiceE",
+                                                              "rules": Array [
+                                                                "
+  display: inline-block;
+
+  > svg {
+    float: left;
+  }
+",
+                                                              ],
+                                                            },
+                                                            "displayName": "styled.i",
+                                                            "foldedComponentIds": Array [],
+                                                            "render": [Function],
+                                                            "styledComponentId": "sc-htpNat",
+                                                            "target": "i",
+                                                            "toString": [Function],
+                                                            "warnTooManyClasses": [Function],
+                                                            "withComponent": [Function],
+                                                          }
+                                                        }
+                                                        forwardedRef={null}
+                                                      >
+                                                        <i
+                                                          className="sc-htpNat jgiceE"
+                                                        >
+                                                          <Close
+                                                            height="1.1em"
+                                                            style={
+                                                              Object {
+                                                                "fill": "currentColor",
+                                                                "stroke": undefined,
+                                                              }
+                                                            }
+                                                            viewBox="0 0 24 24"
+                                                            width="1.1em"
+                                                          >
+                                                            <svg
+                                                              height="1.1em"
+                                                              style={
+                                                                Object {
+                                                                  "fill": "currentColor",
+                                                                  "stroke": undefined,
+                                                                }
+                                                              }
+                                                              viewBox="0 0 24 24"
+                                                              width="1.1em"
+                                                            >
+                                                              <path
+                                                                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                                              />
+                                                            </svg>
+                                                          </Close>
+                                                        </i>
+                                                      </StyledComponent>
+                                                    </styled.i>
+                                                  </Icon>
+                                                </a>
+                                              </StyledComponent>
+                                            </styled.a>
+                                          </CloseButton>
+                                          <styled.div>
+                                            <StyledComponent
+                                              forwardedComponent={
+                                                Object {
+                                                  "$$typeof": Symbol(react.forward_ref),
+                                                  "attrs": Array [],
+                                                  "componentStyle": ComponentStyle {
+                                                    "componentId": "sc-ckVGcZ",
+                                                    "isStatic": true,
+                                                    "lastClassName": "fvuixH",
+                                                    "rules": Array [
+                                                      "
+  box-sizing: border-box;
+  margin: 0;
+",
+                                                    ],
+                                                  },
+                                                  "displayName": "styled.div",
+                                                  "foldedComponentIds": Array [],
+                                                  "render": [Function],
+                                                  "styledComponentId": "sc-ckVGcZ",
+                                                  "target": "div",
+                                                  "toString": [Function],
+                                                  "warnTooManyClasses": [Function],
+                                                  "withComponent": [Function],
+                                                }
+                                              }
+                                              forwardedRef={null}
+                                            >
+                                              <div
+                                                className="sc-ckVGcZ fvuixH"
+                                              >
+                                                <styled.li
+                                                  hovered={false}
+                                                  key="1-0"
+                                                  onClick={[Function]}
+                                                  onMouseMove={[Function]}
+                                                  selected={true}
+                                                >
+                                                  <StyledComponent
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-cvbbAY",
+                                                          "isStatic": false,
+                                                          "lastClassName": "eAHqky",
+                                                          "rules": Array [
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "displayName": "styled.li",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-cvbbAY",
+                                                        "target": "li",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={[Function]}
+                                                    hovered={false}
+                                                    onClick={[Function]}
+                                                    onMouseMove={[Function]}
+                                                    selected={true}
+                                                  >
+                                                    <li
+                                                      className="sc-cvbbAY eAHqky"
+                                                      onClick={[Function]}
+                                                      onMouseMove={[Function]}
+                                                      selected={true}
+                                                    >
+                                                      <styled.div>
+                                                        <StyledComponent
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-jWBwVP",
+                                                                "isStatic": true,
+                                                                "lastClassName": "jZcPPp",
+                                                                "rules": Array [
+                                                                  "
+  display: flex;
+  align-items: center;
+",
+                                                                ],
+                                                              },
+                                                              "displayName": "styled.div",
+                                                              "foldedComponentIds": Array [],
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-jWBwVP",
+                                                              "target": "div",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                        >
+                                                          <div
+                                                            className="sc-jWBwVP jZcPPp"
+                                                          >
+                                                            <styled.div>
+                                                              <StyledComponent
+                                                                forwardedComponent={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "attrs": Array [],
+                                                                    "componentStyle": ComponentStyle {
+                                                                      "componentId": "sc-brqgnP",
+                                                                      "isStatic": true,
+                                                                      "lastClassName": "jgYEci",
+                                                                      "rules": Array [
+                                                                        "
+  flex-grow: 1;
+",
+                                                                      ],
+                                                                    },
+                                                                    "displayName": "styled.div",
+                                                                    "foldedComponentIds": Array [],
+                                                                    "render": [Function],
+                                                                    "styledComponentId": "sc-brqgnP",
+                                                                    "target": "div",
+                                                                    "toString": [Function],
+                                                                    "warnTooManyClasses": [Function],
+                                                                    "withComponent": [Function],
+                                                                  }
+                                                                }
+                                                                forwardedRef={null}
+                                                              >
+                                                                <div
+                                                                  className="sc-brqgnP jgYEci"
+                                                                >
+                                                                  <styled.div
+                                                                    condensed={false}
+                                                                    showTick={false}
+                                                                  >
+                                                                    <StyledComponent
+                                                                      condensed={false}
+                                                                      forwardedComponent={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "attrs": Array [],
+                                                                          "componentStyle": ComponentStyle {
+                                                                            "componentId": "sc-cMljjf",
+                                                                            "isStatic": false,
+                                                                            "lastClassName": "gZZzyn",
+                                                                            "rules": Array [
+                                                                              "
+  padding: ",
+                                                                              [Function],
+                                                                              ";
+  ",
+                                                                              [Function],
+                                                                              ";
+",
+                                                                            ],
+                                                                          },
+                                                                          "displayName": "styled.div",
+                                                                          "foldedComponentIds": Array [],
+                                                                          "render": [Function],
+                                                                          "styledComponentId": "sc-cMljjf",
+                                                                          "target": "div",
+                                                                          "toString": [Function],
+                                                                          "warnTooManyClasses": [Function],
+                                                                          "withComponent": [Function],
+                                                                        }
+                                                                      }
+                                                                      forwardedRef={null}
+                                                                      showTick={false}
+                                                                    >
+                                                                      <div
+                                                                        className="sc-cMljjf gZZzyn"
+                                                                      >
+                                                                        1
+                                                                      </div>
+                                                                    </StyledComponent>
+                                                                  </styled.div>
+                                                                </div>
+                                                              </StyledComponent>
+                                                            </styled.div>
+                                                          </div>
+                                                        </StyledComponent>
+                                                      </styled.div>
+                                                    </li>
+                                                  </StyledComponent>
+                                                </styled.li>
+                                                <styled.li
+                                                  hovered={false}
+                                                  key="2-1"
+                                                  onClick={[Function]}
+                                                  onMouseMove={[Function]}
+                                                  selected={false}
+                                                >
+                                                  <StyledComponent
+                                                    forwardedComponent={
+                                                      Object {
+                                                        "$$typeof": Symbol(react.forward_ref),
+                                                        "attrs": Array [],
+                                                        "componentStyle": ComponentStyle {
+                                                          "componentId": "sc-cvbbAY",
+                                                          "isStatic": false,
+                                                          "lastClassName": "eAHqky",
+                                                          "rules": Array [
+                                                            [Function],
+                                                          ],
+                                                        },
+                                                        "displayName": "styled.li",
+                                                        "foldedComponentIds": Array [],
+                                                        "render": [Function],
+                                                        "styledComponentId": "sc-cvbbAY",
+                                                        "target": "li",
+                                                        "toString": [Function],
+                                                        "warnTooManyClasses": [Function],
+                                                        "withComponent": [Function],
+                                                      }
+                                                    }
+                                                    forwardedRef={[Function]}
+                                                    hovered={false}
+                                                    onClick={[Function]}
+                                                    onMouseMove={[Function]}
+                                                    selected={false}
+                                                  >
+                                                    <li
+                                                      className="sc-cvbbAY eAHqky"
+                                                      onClick={[Function]}
+                                                      onMouseMove={[Function]}
+                                                      selected={false}
+                                                    >
+                                                      <styled.div>
+                                                        <StyledComponent
+                                                          forwardedComponent={
+                                                            Object {
+                                                              "$$typeof": Symbol(react.forward_ref),
+                                                              "attrs": Array [],
+                                                              "componentStyle": ComponentStyle {
+                                                                "componentId": "sc-jWBwVP",
+                                                                "isStatic": true,
+                                                                "lastClassName": "jZcPPp",
+                                                                "rules": Array [
+                                                                  "
+  display: flex;
+  align-items: center;
+",
+                                                                ],
+                                                              },
+                                                              "displayName": "styled.div",
+                                                              "foldedComponentIds": Array [],
+                                                              "render": [Function],
+                                                              "styledComponentId": "sc-jWBwVP",
+                                                              "target": "div",
+                                                              "toString": [Function],
+                                                              "warnTooManyClasses": [Function],
+                                                              "withComponent": [Function],
+                                                            }
+                                                          }
+                                                          forwardedRef={null}
+                                                        >
+                                                          <div
+                                                            className="sc-jWBwVP jZcPPp"
+                                                          >
+                                                            <styled.div>
+                                                              <StyledComponent
+                                                                forwardedComponent={
+                                                                  Object {
+                                                                    "$$typeof": Symbol(react.forward_ref),
+                                                                    "attrs": Array [],
+                                                                    "componentStyle": ComponentStyle {
+                                                                      "componentId": "sc-brqgnP",
+                                                                      "isStatic": true,
+                                                                      "lastClassName": "jgYEci",
+                                                                      "rules": Array [
+                                                                        "
+  flex-grow: 1;
+",
+                                                                      ],
+                                                                    },
+                                                                    "displayName": "styled.div",
+                                                                    "foldedComponentIds": Array [],
+                                                                    "render": [Function],
+                                                                    "styledComponentId": "sc-brqgnP",
+                                                                    "target": "div",
+                                                                    "toString": [Function],
+                                                                    "warnTooManyClasses": [Function],
+                                                                    "withComponent": [Function],
+                                                                  }
+                                                                }
+                                                                forwardedRef={null}
+                                                              >
+                                                                <div
+                                                                  className="sc-brqgnP jgYEci"
+                                                                >
+                                                                  <styled.div
+                                                                    condensed={false}
+                                                                    showTick={false}
+                                                                  >
+                                                                    <StyledComponent
+                                                                      condensed={false}
+                                                                      forwardedComponent={
+                                                                        Object {
+                                                                          "$$typeof": Symbol(react.forward_ref),
+                                                                          "attrs": Array [],
+                                                                          "componentStyle": ComponentStyle {
+                                                                            "componentId": "sc-cMljjf",
+                                                                            "isStatic": false,
+                                                                            "lastClassName": "gZZzyn",
+                                                                            "rules": Array [
+                                                                              "
+  padding: ",
+                                                                              [Function],
+                                                                              ";
+  ",
+                                                                              [Function],
+                                                                              ";
+",
+                                                                            ],
+                                                                          },
+                                                                          "displayName": "styled.div",
+                                                                          "foldedComponentIds": Array [],
+                                                                          "render": [Function],
+                                                                          "styledComponentId": "sc-cMljjf",
+                                                                          "target": "div",
+                                                                          "toString": [Function],
+                                                                          "warnTooManyClasses": [Function],
+                                                                          "withComponent": [Function],
+                                                                        }
+                                                                      }
+                                                                      forwardedRef={null}
+                                                                      showTick={false}
+                                                                    >
+                                                                      <div
+                                                                        className="sc-cMljjf gZZzyn"
+                                                                      >
+                                                                        2
+                                                                      </div>
+                                                                    </StyledComponent>
+                                                                  </styled.div>
+                                                                </div>
+                                                              </StyledComponent>
+                                                            </styled.div>
+                                                          </div>
+                                                        </StyledComponent>
+                                                      </styled.div>
+                                                    </li>
+                                                  </StyledComponent>
+                                                </styled.li>
+                                              </div>
+                                            </StyledComponent>
+                                          </styled.div>
+                                        </div>
+                                      </StyledComponent>
+                                    </styled.div>
+                                    <styled.a
+                                      href="#"
+                                      onFocus={[Function]}
+                                    >
+                                      <StyledComponent
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "sc-kgoBCf",
+                                              "isStatic": true,
+                                              "lastClassName": "ccpxKu",
+                                              "rules": Array [
+                                                "
+  height: 0;
+  width: 0;
+  overflow: hidden;
+",
+                                              ],
+                                            },
+                                            "displayName": "styled.a",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "sc-kgoBCf",
+                                            "target": "a",
+                                            "toString": [Function],
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={null}
+                                        href="#"
+                                        onFocus={[Function]}
+                                      >
+                                        <a
+                                          className="sc-kgoBCf ccpxKu"
+                                          href="#"
+                                          onFocus={[Function]}
+                                        />
+                                      </StyledComponent>
+                                    </styled.a>
+                                  </div>
+                                </StyledComponent>
+                              </styled.div>
+                              <Styled(styled.div)
+                                className="sc-fBuWsC eySOLS"
+                              >
+                                <StyledComponent
+                                  className="sc-fBuWsC eySOLS"
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "sc-kGXeez",
+                                        "isStatic": true,
+                                        "lastClassName": "fMcQrw",
+                                        "rules": Array [
+                                          "
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  position: fixed;
+  z-index: 10000;
+  overflow-x: hidden;
+  overflow-y: auto;
+",
+                                          "
+  overflow: hidden;
+  z-index: 9999;
+  background: ",
+                                          "rgba(64, 64, 64, 0.4)",
+                                          ";
+",
+                                        ],
+                                      },
+                                      "displayName": "Styled(styled.div)",
+                                      "foldedComponentIds": Array [
+                                        "sc-chPdSV",
+                                      ],
+                                      "render": [Function],
+                                      "styledComponentId": "sc-kGXeez",
+                                      "target": "div",
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={null}
+                                >
+                                  <div
+                                    className="sc-chPdSV sc-fBuWsC eySOLS sc-kGXeez fMcQrw"
+                                  />
+                                </StyledComponent>
+                              </Styled(styled.div)>
+                            </Blocker>
+                          </WindowPopup>
+                        </StyledComponent>
+                      </Styled(WindowPopup)>
+                    </Component>
+                  </div>
+                </StyledComponent>
+              </styled.div>
+            </InteractiveListInt>
+          </InteractiveList>
+        </Responsive>
+      </div>
+    </StyledComponent>
+  </styled.div>
+</DropdownFieldInt>
+`;
+
 exports[`<DropdownField /> should render a <DropdownField> that does not render a placeholder 1`] = `
 <DropdownFieldInt
   data={

--- a/src/components/InteractiveList/InteractiveList.types.part.tsx
+++ b/src/components/InteractiveList/InteractiveList.types.part.tsx
@@ -108,6 +108,11 @@ export interface InteractiveListProps extends StandardProps {
    * Event fired when clicked outside of the component
    */
   onClickOutside?(): void;
+  /**
+   * Whether to position the list to top or bottom.
+   * Either `0` (bottom) or `1` (top). Make sure that the value provided is number.
+   */
+  direction?: InteractiveListDirection;
 }
 
 export interface InteractiveListState {

--- a/src/components/InteractiveList/InteractiveListInt.part.tsx
+++ b/src/components/InteractiveList/InteractiveListInt.part.tsx
@@ -190,7 +190,7 @@ export class InteractiveListInt extends React.PureComponent<InteractiveListProps
       value: props.indices || getIndices(props.data || [], value, props.multiple),
       controlled: props.indices !== undefined || props.value !== undefined,
       selected: undefined,
-      direction: InteractiveListDirection.normal,
+      direction: props.direction || InteractiveListDirection.normal,
     };
   }
 


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

By default the list is positioned automatically based on the screen size (whether towards the top or bottom, depending on available space on the screen). There is an option to override this behavior by `direction` prop (`0` - bottom, `1` - top).

 ```jsx
const { DropdownField } = require('precise-ui');

 <DropdownField data={['first', 'second']} direction={0}/>
```

In addition, we can open the list immediately after render occurred:
```jsx
const { DropdownField } = require('precise-ui');
<DropdownField open data={['first', 'second']}/>
```