### PR TITLE
DateField: fix default format and add types' exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Removed `SASS` support 
 - Fixed: Modal closes on drag and release cursor outside modal (#152)
 - Improved `Responsive` component to avoid using of combined screen sizes
+- Fixed(DateField): Use valid date format as a default  - `yyyy-MM-dd` instead of `dd-MM-yyyy`
 
 ## 0.7.1
 

--- a/src/components/DateField/DateFieldInt.part.tsx
+++ b/src/components/DateField/DateFieldInt.part.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
-import { TextInputProps, Omit, InputChangeEvent } from '../../common';
 import { ReactDatePickerProps } from 'react-datepicker';
-import { FormContextProps, withFormContext } from '../../hoc/withFormContext';
+import { TextInputProps, Omit, InputChangeEvent } from '../../common';
+import { FormContextProps, withFormContext } from '../../hoc';
 import { CustomReactDatepicker } from './CustomReactDatepicker.part';
 import { DatePickerTextField } from './DateFieldTextField.part';
-import { parseDate, safeDateFormat } from '../../utils/date';
+import { parseDate, safeDateFormat } from '../../utils';
+
+export { ReactDatePickerProps };
 
 export interface DateFieldOpenChangedEvent {
   /**
@@ -136,11 +138,11 @@ const excludedReactDatePickerProps = {
   showMonthYearPicker: 1,
 };
 
-interface DatePickerOnChangeEvent extends InputChangeEvent<string> {
+export interface DatePickerOnChangeEvent extends InputChangeEvent<string> {
   date: Date;
 }
 
-interface DateFieldBasicProps extends FormContextProps, TextInputProps {
+export interface DateFieldBasicProps extends FormContextProps, TextInputProps {
   /**
    * Optional abbreviations for the 12 months (Jan - Dec) of the year to use.
    */
@@ -161,7 +163,7 @@ interface DateFieldBasicProps extends FormContextProps, TextInputProps {
   /**
    * Event emitted once the value changes due to user input.
    */
-  onChange(e: DatePickerOnChangeEvent): void;
+  onChange?(e: DatePickerOnChangeEvent): void;
   /**
    * @ignore
    */
@@ -177,10 +179,10 @@ interface DateFieldState {
   error?: React.ReactChild;
 }
 
-const defaultDateFormat = 'dd-MM-yyyy';
+const DefaultDateFormat = 'yyyy-MM-dd';
 
 class DateFieldInt extends React.Component<DateFieldProps, DateFieldState> {
-  private valueControlled: boolean;
+  private readonly valueControlled: boolean;
 
   constructor(props: DateFieldProps) {
     super(props);
@@ -231,7 +233,7 @@ class DateFieldInt extends React.Component<DateFieldProps, DateFieldState> {
   }
 
   private changeValue: ReactDatePickerProps['onChange'] = inputDate => {
-    const { dateFormat = defaultDateFormat, locale } = this.props;
+    const { dateFormat = DefaultDateFormat, locale } = this.props;
     const date = inputDate || new Date();
 
     const value = safeDateFormat(date, {
@@ -253,7 +255,7 @@ class DateFieldInt extends React.Component<DateFieldProps, DateFieldState> {
   };
 
   private parseDate = (value: string) => {
-    const { locale, dateFormat = defaultDateFormat, strictParsing } = this.props;
+    const { locale, dateFormat = DefaultDateFormat, strictParsing } = this.props;
     return parseDate(value, dateFormat, locale, strictParsing) || new Date();
   };
 

--- a/src/components/DateField/index.tsx
+++ b/src/components/DateField/index.tsx
@@ -1,4 +1,10 @@
-export { DateField, DateFieldOpenChangedEvent, DateFieldProps } from './DateFieldInt.part';
+export {
+  DateField,
+  DateFieldOpenChangedEvent,
+  DatePickerOnChangeEvent,
+  ReactDatePickerProps,
+  DateFieldProps,
+} from './DateFieldInt.part';
 
 /**
  * @deprecated


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

### Description

Currently, DateField uses `dd-MM-yyyy` as a default date format. It's invalid date string format for JavaScript's Date object:
```console
> new Date('30-12-2019')
> Invalid Date
```
I changed it to **`yyyy-MM-dd`**.

PS: also added imports for types/interfaces
