### PR TITLE
Allow theming of Tag component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added onBeforeClose event to Modal
 - Added appendTagOnBlur prop to TagBuilder
 - Added onSort callback to Table
+- Fixed(Tag): Theming of tag component (#190)
 
 ## 0.8.2
 

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -83,6 +83,6 @@ const defaultType: TagType = 'primary';
  * The tag component represents a simple block with a typed color and content.
  */
 export const Tag: React.SFC<TagProps> = ({ type = defaultType, ...props }) => (
-  <StyledTag {...props} theme={getStyle(type)} />
+  <StyledTag theme={getStyle(type)} {...props} />
 );
 Tag.displayName = 'Tag';


### PR DESCRIPTION
Currently the Tag component can not be themed, as internal styling is always applied. This commit changes this by prioritizing theme related changes applied from outside over internal defaults.

## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Allows theming of tag component by prioritising external themes over internal defaults.

Fixes #189.
