### PR TITLE
Allow styling of notification icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added onBeforeClose event to Modal
 - Added appendTagOnBlur prop to TagBuilder
 - Added onSort callback to Table
+- Allow themeing of icon of notification component
 
 ## 0.8.2
 

--- a/src/components/Notification/index.tsx
+++ b/src/components/Notification/index.tsx
@@ -209,7 +209,7 @@ export class Notification extends React.Component<NotificationProps, Notificatio
     return (
       <StyledNotification theme={theme} closed={closed} type={type} {...other}>
         <IconContainer theme={theme}>
-          <StyledIcon type={type} name={getNotificationIcon(type)} size="22px" />
+          <StyledIcon type={type} name={getNotificationIcon(type)} size="22px" theme={theme} />
         </IconContainer>
         <ContentContainer inline={isInline}>
           {title && <StyledTitle theme={theme}>{title}</StyledTitle>}


### PR DESCRIPTION
theme property is now applied to notification icon so that surrounding components can style this notification icon the way they want to.

## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Allow styling of notification icon. Before it was not possible to change the style of the icon inside a notification as the theme property was not applied. This is now changed.

Fixes #191 
