### PR TITLE
Fix unit test execution if repository path contains "src"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added onBeforeClose event to Modal
 - Added appendTagOnBlur prop to TagBuilder
 - Added onSort callback to Table
+- Fixed: Integration tests are always executed if repository is stored in a location with `src` in it's path
 
 ## 0.8.2
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,4 +12,5 @@ module.exports = {
       diagnostics: false,
     },
   },
+  roots: ['src'],
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}' --project tsconfig.json",
     "test": "npm run lint && npm run test:unit",
     "test:visual": "jest -c integration/jest.config.js --noStackTrace --runInBand",
-    "test:unit": "cross-env NODE_ENV=test jest --roots=src",
+    "test:unit": "cross-env NODE_ENV=test jest",
     "test:watch": "npm run test:unit -- --watch",
     "prettier": "prettier --config prettier.config.js --write 'src/**/*.{ts,tsx}'",
     "build": "rimraf dist && npm run build:bundle && npm run build:es5 && npm run build:es6",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}' --project tsconfig.json",
     "test": "npm run lint && npm run test:unit",
     "test:visual": "jest -c integration/jest.config.js --noStackTrace --runInBand",
-    "test:unit": "cross-env NODE_ENV=test jest src",
+    "test:unit": "cross-env NODE_ENV=test jest --roots=src",
     "test:watch": "npm run test:unit -- --watch",
     "prettier": "prettier --config prettier.config.js --write 'src/**/*.{ts,tsx}'",
     "build": "rimraf dist && npm run build:bundle && npm run build:es5 && npm run build:es6",


### PR DESCRIPTION
Until now npm unit:test executed all tests (including integration test) if a parent directory contained 'src' in it's name. This commit fixes this by limiting the jest search scope to the src dir in the current working directory.

## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Fixes #193 .