### PR TITLE
Fix `InteractiveList` position in `Autocomplete` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Fixed(Tag): Theming of tag component (#190)
 - Allow themeing of icon of notification component
 - Fixed: Integration tests are always executed if repository is stored in a location with `src` in it's path
-- Fixed "Autocomplete" that blocked "InteractiveList" automatic position determination4f3cc2f7d36b938005d99031058a1a066
+- Fixed `Autocomplete` that blocked `InteractiveList` automatic position determination
+- Fixed `InteractiveList` position in `Autocomplete` component
 
 ## 0.8.2
 

--- a/src/components/Autocomplete/index.tsx
+++ b/src/components/Autocomplete/index.tsx
@@ -93,7 +93,7 @@ const StyledAutosuggestWrapper = styled.ul<StyledAutosuggestWrapperProps>(
         : 'border-bottom-color: transparent'};
       max-height: 50vh;
       position: absolute;
-      top: ${direction === InteractiveListDirection.normal ? '0' : '-100%'};
+      top: ${direction === InteractiveListDirection.normal ? '100%' : '0px'};
       transform: translateY(${direction === InteractiveListDirection.normal ? 0 : -100}%);
       overflow-y: auto;
       z-index: 100;
@@ -345,6 +345,7 @@ class AutocompleteInt<T> extends React.Component<AutocompleteProps<T> & FormCont
             onChange={this.handleListChange}
             autoPosition
             open={isListOpen}
+            style={{ position: 'static' }}
           />
           {isListOpen && info && <div>{info}</div>}
         </AutocompleteWrapper>

--- a/src/components/Autocomplete/index.tsx
+++ b/src/components/Autocomplete/index.tsx
@@ -73,6 +73,10 @@ const AutocompleteWrapper = styled.div`
   position: relative;
 `;
 
+const StyledInteractiveList = styled(InteractiveList)`
+  position: static;
+`;
+
 interface StyledAutosuggestWrapperProps {
   direction: InteractiveListDirection;
 }
@@ -333,7 +337,7 @@ class AutocompleteInt<T> extends React.Component<AutocompleteProps<T> & FormCont
             value: value,
             error: error,
           })}
-          <InteractiveList
+          <StyledInteractiveList
             data={
               suggestions.length
                 ? suggestions.map(renderSuggestion)
@@ -345,7 +349,6 @@ class AutocompleteInt<T> extends React.Component<AutocompleteProps<T> & FormCont
             onChange={this.handleListChange}
             autoPosition
             open={isListOpen}
-            style={{ position: 'static' }}
           />
           {isListOpen && info && <div>{info}</div>}
         </AutocompleteWrapper>


### PR DESCRIPTION
## Types of Changes

### Prerequisites
- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

It was: 
![image](https://user-images.githubusercontent.com/11165501/67860582-81fddf00-fb1e-11e9-8fa5-c5d761a2460f.png)
It will be 
![image](https://user-images.githubusercontent.com/11165501/67860587-86c29300-fb1e-11e9-8bbf-0b42aedfed58.png)

The interactive list will be displayed above the field without overlapping. 