### PR TITLE
Fix undefined or null as children of List

### DIFF
--- a/src/components/List/List.test.tsx
+++ b/src/components/List/List.test.tsx
@@ -17,6 +17,27 @@ describe('<List />', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should not render children that are null or undefined', () => {
+    const wrapper = enzyme.shallow(
+      <List disablePadding>
+        <div>Item</div>
+        {null}
+        {undefined}
+      </List>,
+    );
+    expect(wrapper.children().length).toBe(1);
+  });
+
+  it('should render children that are primitives', () => {
+    const wrapper = enzyme.shallow(
+      <List disablePadding>
+        {'Nice '}
+        {1}
+      </List>,
+    );
+    expect(wrapper.text()).toBe('Nice 1');
+  });
+
   it('should set `active` property on 2nd child element', () => {
     const wrapper = enzyme.shallow(
       <List activeItem={2}>

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -45,13 +45,15 @@ const StyledList = styled.ul<ListProps>`
  * General purpose list component which can be used for rendering list items.
  */
 export const List: React.SFC<ListProps> = ({ disablePadding, borderless, children, activeItem, ...props }) => {
-  const listItems = React.Children.map(children, (child: React.ReactElement<any>, index) =>
-    React.cloneElement(child, {
-      ...(disablePadding !== undefined ? { disablePadding } : undefined),
-      ...(borderless !== undefined ? { border: !borderless } : undefined),
-      ...child.props,
-      ...(activeItem !== undefined ? { active: index === activeItem } : {}),
-    }),
+  const listItems = React.Children.map(children, (child, index) =>
+    React.isValidElement(child)
+      ? React.cloneElement(child, {
+          ...(disablePadding !== undefined ? { disablePadding } : undefined),
+          ...(borderless !== undefined ? { border: !borderless } : undefined),
+          ...child.props,
+          ...(activeItem !== undefined ? { active: index === activeItem } : {}),
+        })
+      : child,
   );
 
   return <StyledList {...props}>{listItems}</StyledList>;


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project -> Where is the code style described?

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Given the code:

```jsx
<List>
    <ListItem>1</ListItem>
    {showOptional ? <ListItem>1</ListItem> : null}
</List>
```

Before:
This would crash when `showOptional` is `false`, as it would try to access the `props` property of `null`. Generally the `<List>` causes a crash whenever a primitive (e.g. string) is used as a child.

Now:
All primitives (strings, numbers, null, undefined, ...) can be used as children of the `List` element, without any crashes.