### PR TITLE
fix(Accordion): header strips spaces when html tags are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed `InteractiveList` position in `Autocomplete` component
 - Replaced `forEach` with `Array.from` in `ContentSwitchInt` to fix displaying content switch for IE 11
 - Fixed(Blocker): Closing modal when using scrollbars (#203)
+- Fix(Accordion): header strips spaces when html tags are used
 
 ## 0.8.2
 
@@ -32,7 +33,7 @@
 ## 0.8.0
 
 - Implement new breakpoints and screen sizes
-- Removed `SASS` support 
+- Removed `SASS` support
 - Fixed: Modal closes on drag and release cursor outside modal (#152)
 - Improved `Responsive` component to avoid using of combined screen sizes
 - Fixed(DateField): Use valid date format as a default  - `yyyy-MM-dd` instead of `dd-MM-yyyy`
@@ -47,7 +48,7 @@
 - Fixed horizontal padding for InputInfo and InputError
 - Hide info element on open Autocomplete list
 - Fixed overview pagination elements' layout in IE 11
-- Fixed display of label, placeholder and info on AutocompleteTagBuilder 
+- Fixed display of label, placeholder and info on AutocompleteTagBuilder
 - Fixed toaster action click area
 - Fixed two cross(clear) buttons displayed inside TextField in IE 11
 - Fixed `Styled Input Box` flex layout for IE 11

--- a/src/components/Accordion/AccordionBasic.part.tsx
+++ b/src/components/Accordion/AccordionBasic.part.tsx
@@ -62,6 +62,7 @@ const AccordionItemHeaderContainer = styled('div')<AccordionItemProps>`
 
 const AccordionItemHeader = styled.div`
   display: flex;
+  white-space: pre-wrap;
   align-items: center;
   cursor: pointer;
   padding: ${themed(({ theme }) => theme.accordionPadding)};

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`<Accordion /> should render a <Accordion> component with several tabs 1
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  white-space: pre-wrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -273,6 +274,7 @@ exports[`<Accordion /> should render a <Accordion> component with several tabs 1
                                             "rules": Array [
                                               "
   display: flex;
+  white-space: pre-wrap;
   align-items: center;
   cursor: pointer;
   padding: ",
@@ -556,6 +558,7 @@ exports[`<Accordion /> should render a <Accordion> component with several tabs 1
                                             "rules": Array [
                                               "
   display: flex;
+  white-space: pre-wrap;
   align-items: center;
   cursor: pointer;
   padding: ",
@@ -839,6 +842,7 @@ exports[`<Accordion /> should render a <Accordion> component with several tabs 1
                                             "rules": Array [
                                               "
   display: flex;
+  white-space: pre-wrap;
   align-items: center;
   cursor: pointer;
   padding: ",
@@ -1122,6 +1126,7 @@ exports[`<Accordion /> should render a <Accordion> component with several tabs 1
                                             "rules": Array [
                                               "
   display: flex;
+  white-space: pre-wrap;
   align-items: center;
   cursor: pointer;
   padding: ",
@@ -1352,6 +1357,7 @@ exports[`<Accordion /> should render a <Accordion> component with several tabs i
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  white-space: pre-wrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1603,6 +1609,7 @@ exports[`<Accordion /> should render a <Accordion> component with several tabs i
                                             "rules": Array [
                                               "
   display: flex;
+  white-space: pre-wrap;
   align-items: center;
   cursor: pointer;
   padding: ",
@@ -1886,6 +1893,7 @@ exports[`<Accordion /> should render a <Accordion> component with several tabs i
                                             "rules": Array [
                                               "
   display: flex;
+  white-space: pre-wrap;
   align-items: center;
   cursor: pointer;
   padding: ",
@@ -2269,6 +2277,7 @@ exports[`<Accordion /> should render a <Accordion> component with several tabs i
                                             "rules": Array [
                                               "
   display: flex;
+  white-space: pre-wrap;
   align-items: center;
   cursor: pointer;
   padding: ",


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [X] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

### Description

fix(Accordion): header strips spaces when html tags are used

Use the following example:

<Accordion>
  <AccordionTab header={<><span>hello</span><span> world!</span></>}>
    {<><span>hello</span><span> world!</span></>}
  </AccordionTab>
</Accordion>

Expected behavior: You should read "hello world!"
Actual behavior: You read "helloworld!"

Closes: #209
