### PR TITLE
Add missing onDataClick handler for Table mobile view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed `InteractiveList` position in `Autocomplete` component
 - Replaced `forEach` with `Array.from` in `ContentSwitchInt` to fix displaying content switch for IE 11
 - Fixed(Blocker): Closing modal when using scrollbars (#203)
+- Fixed missing onDataClick handler for Table component in mobile view (#214)
 
 ## 0.8.2
 

--- a/src/components/Table/TableCard.part.tsx
+++ b/src/components/Table/TableCard.part.tsx
@@ -110,7 +110,7 @@ export class TableCard<T> extends React.Component<TableProps<T>> {
           });
 
           return (
-            <PropContainer key={colIndex}>
+            <PropContainer key={colIndex} onClick={e => this.dataClicked(e, rowIndex, colIndex, key)}>
               <PropName>{propKey}</PropName>
               <PropValue>{value}</PropValue>
             </PropContainer>
@@ -120,6 +120,22 @@ export class TableCard<T> extends React.Component<TableProps<T>> {
         return undefined;
       })
       .filter(m => !!m);
+  }
+
+  private dataClicked(e: React.MouseEvent<HTMLDivElement>, row: number, column: number, key: string) {
+    const { onDataClick, data } = this.props;
+    e.preventDefault();
+
+    if (typeof onDataClick === 'function') {
+      const d = data[row];
+      onDataClick({
+        row,
+        column,
+        key,
+        data: d,
+        value: d && (column === -1 ? row + 1 : d[key]),
+      });
+    }
   }
 
   render() {


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Issue #214:
Table component in mobile view (TableCard) was missing onDataClick handler. Reused the one from regular view (TableBasic) with slight adjustment to type. All tests pass without errors, build runs as the feature has been tested locally.
