### PR TITLE
Adding edge:true to fix incompatibility with version of travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,14 @@ deploy:
   - provider: npm
     email: $auth_email
     api_key: $auth_token
+    edge: true
     skip_cleanup: true
     on:
       branch: master
   - provider: npm
     email: $auth_email
     api_key: $auth_token
+    edge: true
     skip_cleanup: true
     tag: next
     on:


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

There is an issue on new version on Travis CI Build tool, which requires me to add this `edge:true`.

Discussion can be found on: https://travis-ci.community/t/missing-api-key-when-deploying-to-github-releases/5761/14