### PR TITLE
extended `light` theme with color definitions for new Pharos componen…

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -129,6 +129,21 @@ export interface ButtonThemeSettings {
   lineHeightSmall: string;
 }
 
+export interface ActionButtonThemeSettings {
+  /**
+   * Color of icon background.
+   */
+  iconBackground: string;
+  /**
+   * Color of icon background when hovered.
+   */
+  hoverIconBackground: string;
+  /**
+   * Color of icon background when focused.
+   */
+  focusIconBackground: string;
+}
+
 export type PreciseThemeColors = {
   /**
    * Theme color UI0.
@@ -221,6 +236,10 @@ export interface PreciseFullTheme extends PreciseThemeColors {
    * Colors of the secondary button.
    */
   buttonSecondary: ButtonThemeSettings;
+  /**
+   * Colors of the warning action button.
+   */
+  actionButtonWarning: ActionButtonThemeSettings;
   /**
    * Position of the icon when place inside a button.
    */

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -6,6 +6,7 @@ import {
   FlyoutStyling,
   MetroInfoTileStyling,
   AccordionCardStyling,
+  ActionButtonThemeSettings,
 } from './common';
 import { distance } from './distance';
 import { remCalc } from './utils/remCalc';
@@ -64,6 +65,12 @@ export const buttonSecondary: ButtonThemeSettings = {
   lineHeightSmall: '16px',
 };
 
+export const actionButtonWarning: ActionButtonThemeSettings = {
+  iconBackground: colors.purpleRed,
+  hoverIconBackground: colors.purpleRed5,
+  focusIconBackground: colors.purpleRed6,
+};
+
 export const flyout: FlyoutStyling = {
   maxHeight: '600px',
   maxWidth: '300px',
@@ -110,6 +117,7 @@ export const light: PreciseFullTheme = {
   text7: colors.white,
   buttonPrimary,
   buttonSecondary,
+  actionButtonWarning,
   buttonIconPosition: 'right',
   primary: colors.pacificBlue,
   secondary: colors.lighterGray,


### PR DESCRIPTION
…t `ActionButton` (variant `warning`)

- those colors were not exposed by the theme until now

## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

### Description

extended `light` theme with color definitions for new Pharos component `ActionButton` (variant `warning`)
- those colors were not exposed by the theme until now
