### PR TITLE
Add the ability to clean datetimepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Precise UI Changelog
 
+## 1.2.0
+- Add the ability to clean datetimepicker
+
 ## 1.1.4
 - Add ability to display the files list under the File Uploader
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Precise UI React component library.",
   "main": "dist/es6",
   "typings": "dist/es6",

--- a/src/components/DateField/DateFieldInt.part.tsx
+++ b/src/components/DateField/DateFieldInt.part.tsx
@@ -139,7 +139,7 @@ const excludedReactDatePickerProps = {
 };
 
 export interface DatePickerOnChangeEvent extends InputChangeEvent<string> {
-  date: Date;
+  date?: Date;
 }
 
 export interface DateFieldBasicProps extends FormContextProps, TextInputProps {
@@ -175,7 +175,7 @@ export type DateFieldProps = DateFieldBasicProps &
 
 interface DateFieldState {
   value: string;
-  date: Date;
+  date?: Date;
   error?: React.ReactChild;
 }
 
@@ -234,8 +234,7 @@ class DateFieldInt extends React.Component<DateFieldProps, DateFieldState> {
 
   private changeValue: ReactDatePickerProps['onChange'] = inputDate => {
     const { dateFormat = DefaultDateFormat, locale } = this.props;
-    const date = inputDate || new Date();
-
+    const date = inputDate || undefined;
     const value = safeDateFormat(date, {
       dateFormat,
       locale,
@@ -256,10 +255,10 @@ class DateFieldInt extends React.Component<DateFieldProps, DateFieldState> {
 
   private parseDate = (value: string) => {
     const { locale, dateFormat = DefaultDateFormat, strictParsing } = this.props;
-    return parseDate(value, dateFormat, locale, strictParsing) || new Date();
+    return parseDate(value, dateFormat, locale, strictParsing) || undefined;
   };
 
-  private change = (date: Date, value: string) => {
+  private change = (date: Date | undefined, value: string) => {
     const { onChange, name = '', form } = this.props;
 
     if (!this.valueControlled) {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -126,7 +126,7 @@ function formatDate(date: Date, formatStr: string, locale: string | Locale = '')
 }
 
 export function safeDateFormat(
-  date: Date,
+  date: Date | undefined,
   { dateFormat, locale }: { dateFormat: string | Array<string>; locale?: string | Locale },
 ) {
   return (date && formatDate(date, Array.isArray(dateFormat) ? dateFormat[0] : dateFormat, locale)) || '';


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Users cannot clean DateTime component. After selecting a date, it cannot be deleted. This issue occurs when the field is used as an optional. We should give users a chance to somehow remove the value. 
This version will give the user an ability to clean the field by selecting full input value and pressing on the delete button.
