### PR TITLE
Add custom dialog for Prompt component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,28 @@
 # Precise UI Changelog
 
+## 1.3.0
+
+- Update `Form` component to receive `prompt` prop as component
+- Add custom dialog for `Prompt` component
+
 ## 1.2.0
+
 - Add the ability to clean datetimepicker
 
 ## 1.1.4
+
 - Add ability to display the files list under the File Uploader
 
 ## 1.1.3
+
 - Add new icons
 
 ## 1.1.2
+
 - Fix TagBuilder not deleting tags properly with backspace (#223)
 
 ## 1.1.1
+
 - Added new theme object `actionButtonWarning`
 
 ## 1.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Precise UI React component library.",
   "main": "dist/es6",
   "typings": "dist/es6",

--- a/src/components/Form/Example.md
+++ b/src/components/Form/Example.md
@@ -137,8 +137,8 @@ The `Form` with validation rules
 ```jsx
 const { Form, Button, TextField } = require('precise-ui');
 
-<Form 
-  onSubmit={e => alert(JSON.stringify(e))} 
+<Form
+  onSubmit={e => alert(JSON.stringify(e))}
   validationRules={{
     first: (value) => value && value.length > 10 ? 'Should be less than 10' : undefined,
     last: () => 'Always some error',
@@ -160,3 +160,33 @@ const { Form, Button, TextField } = require('precise-ui');
   </div>
 </Form>
 ```
+
+**Using Prompt with Form**
+
+When form has changes, it is possible to make a prompt, if user wants to leave the page without submitting the form. `Form` component has built-in `Prompt` component.
+
+Simple way to use it is to provide `prompt` prop. It will show browser's system dialog.
+
+```jsx  { "props": { "data-skip": true } }
+const { Form } = require('precise-ui');
+
+<Form prompt="Form has unsaved changes, do you want to leave?">
+{/* other components*/}
+</Form>
+```
+
+It is also possible to provide `Prompt` component, that will show `precise-ui` component instead of system dialog.
+
+```jsx  { "props": { "data-skip": true } }
+const { Form, Prompt } = require('precise-ui');
+
+<Form prompt={(changed: boolean) => {
+  return (
+    <Prompt message="Your form has unsaved messages, are you sure you want to leave the page" when={changed} modalOptions={{ title: 'Do you want to leave' }} />
+  );
+}>
+{/* other components*/}
+</Form>
+```
+
+For more details refer to `Prompt` component examples

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -42,9 +42,9 @@ export interface FormValidationError {
 export interface FormProps<FormValues> extends StandardProps {
   /**
    * Shows the given message if the user wants to navigate
-   * with changes being made.
+   * with changes being made or renders custom component with message if provided.
    */
-  prompt?: string;
+  prompt?: ((changed: boolean) => React.ReactChild) | string;
   /**
    * The value of the form to be used in controlled mode.
    */
@@ -320,7 +320,7 @@ export class Form<Values extends FormValuesData> extends React.Component<FormPro
     const { changed } = this.state;
     return (
       <StyledForm {...rest} onSubmit={this.submit}>
-        {prompt && <Prompt when={changed} message={prompt} />}
+        {prompt && (typeof prompt === 'function' ? prompt(changed) : <Prompt when={changed} message={prompt} />)}
         <FormContext.Provider value={this.ctx}>{children}</FormContext.Provider>
       </StyledForm>
     );

--- a/src/components/Prompt/Example.md
+++ b/src/components/Prompt/Example.md
@@ -1,0 +1,83 @@
+`Prompt` component allows to show a dialog window if user is navigating away from a page. Usual use case for this is when user is about to leave the page with form that has changes without submitting it.
+
+**Note:** For `Prompt` component to work, it needs to have `router` from react-router through context provider. If react-router context is not setup, `PromptBasic`, `PromptModal` or `usePrompt` can be used instead. Look at **Advanced** section.
+
+**Important:** Message passed to the `Prompt` component will be shown during page transitions within the app. If the transition is happening outside of the app (moving to different url host, reloading the page), then browser's system dialog, with system message will be shown. This message cannot be customized.
+
+**Default Mode**
+
+By default, `Prompt` component will display browser's dialog window with custom message.
+
+```jsx { "props": { "data-skip": true } }
+const { Prompt } = require('precise-ui');
+
+<Prompt message="Hey, are you sure you want to leave the page" />
+```
+
+**Custom Modal Mode**
+
+`Prompt` component can also display custom component when navigation between pages inside application.
+
+
+```jsx { "props": { "data-skip": true } }
+const { Prompt } = require('precise-ui');
+
+<Prompt message="Hey, are you sure you want to leave the page" modalOptions={{title: "Leaving page..."}}/>
+```
+
+**Using with Form**
+
+As stated above, usual use case for using `Prompt` component is together `Form` component.
+
+`Prompt` component is built-in in `Form` component, so the easiet way to use it with form is by providing `prompt` prop to `Form`. For details, refer to `Form` component examples
+
+
+**Advanced**
+
+Simple `Prompt` component uses `react-router`'s history object from context. However, of there is no context, then `history` can be passed in directly.
+
+```jsx { "props": { "data-skip": true } }
+const { PromptModal, Button, Checkbox} = require('precise-ui');
+
+/* Simulation of the react-router's history object */
+let cb;
+const history = {
+  location: {
+    pathname: "/"
+  },
+  block: (loc) => {
+    cb = loc;
+    return () => {
+      cb = undefined
+    }
+  },
+  push: (path) => {
+    alert('user pressed ok. at this pointed, he will be navigated to different page')
+  }
+}
+
+const simulateNavigation = () => cb && cb({pathname: "/new"});
+/* end */
+
+class PromptExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      enable: false,
+    };
+  }
+  render() {
+    const {enable} = this.state
+    return (<>
+
+    <Checkbox value={enable} onChange={()=>this.setState({enable: !enable})}>Enable prompt on page change</Checkbox>
+    <br/>
+    <ActionLink onClick={simulateNavigation}>Simulate navigation to differnt page</ActionLink>
+    <PromptModal when={enable} history={history} message="Your Form contains unsaved data" modalOptions={{title: "Are you sure you want to leave", confirmText: "Leave", cancelText: "Stay", onConfirm: ()=>{console.log("user is navigating to different page")}, onCancel: ()=>{console.log("user decided to stay in the page")}}} /></>);
+  }
+}
+
+<PromptExample/>
+```
+
+To create custom Modal (or any other functionality that ask before navigating to different page), `usePrompt` hook can be used. For details on how to use look at implementation of `PromptModal` component (`PromptModal.tsx`)

--- a/src/components/Prompt/Prompt.types.ts
+++ b/src/components/Prompt/Prompt.types.ts
@@ -1,0 +1,85 @@
+export interface PromptProps {
+  /**
+   * Determines if the prompt should be active. By default true.
+   * @default true
+   */
+  when?: boolean;
+  /**
+   * Creates the message to show for the blocked route, if any.
+   */
+  message: string | PromptMessageCallback;
+  /**
+   * Additional options for Modal Dialog. If options are not passed, browser's system dialog is used
+   */
+  modalOptions?: PromptDefaultModalOptions;
+}
+
+export interface PromptBasicProps extends PromptProps {
+  /**
+   * `history` object of react-router
+   */
+  history?: PromptHistory;
+  /**
+   * Determines if the prompt should be active.
+   */
+  when: boolean;
+}
+
+export interface PromptModalProps extends Required<PromptProps> {
+  /**
+   * `history` object of react-router
+   */
+  history?: PromptHistory;
+}
+
+export interface PromptMessageCallback {
+  (location: any): boolean | string;
+}
+
+export interface PromptLocation {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+export interface PromptHistory {
+  location: PromptLocation;
+  block: PromptHistoryBlockCallback;
+  push(path: string, state?: any): void;
+}
+
+export interface PromptHistoryBlockCallback {
+  (cb: (location: Location) => any): PromptCallback;
+}
+
+export interface PromptCallback {
+  (): boolean | string;
+}
+
+export interface PromptDefaultModalOptions {
+  /**
+   * Title in the modal
+   */
+  title: string;
+  /**
+   * Text on confirm button
+   */
+  confirmText?: string;
+  /**
+   * Text on cancel button
+   */
+  cancelText?: string;
+  /**
+   * Callback called after user confirms
+   */
+  onConfirm(): void;
+  /**
+   * Callback called after user cancels
+   */
+  onCancel(): void;
+}
+
+export interface PromptDefaultModalProps extends PromptDefaultModalOptions {
+  open: boolean;
+  message: string | boolean;
+}

--- a/src/components/Prompt/PromptBasic.part.tsx
+++ b/src/components/Prompt/PromptBasic.part.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { usePrompt } from './usePrompt';
+import { PromptBasicProps, PromptMessageCallback } from './Prompt.types';
+
+export const PromptBasic: React.FC<PromptBasicProps> = ({ history, when, message }) => {
+  usePrompt(() => getMessage(message), () => getMessage(message), history, when);
+
+  // tslint:disable-next-line
+  return null;
+};
+
+export const getMessage = (message: string | PromptMessageCallback) =>
+  typeof message === 'function' ? message(undefined) : message;

--- a/src/components/Prompt/PromptModal.part.tsx
+++ b/src/components/Prompt/PromptModal.part.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { usePrompt } from './usePrompt';
+import { PromptDefaultModalProps, PromptModalProps } from './Prompt.types';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from '../Modal';
+import { Button } from '../Button';
+import { getMessage } from './PromptBasic.part';
+import { ActionLink } from '../ActionLink';
+import { styled } from '../../utils';
+import { distance } from '../../distance';
+
+export const PromptModal: React.FC<PromptModalProps> = ({ history, when, message, modalOptions }) => {
+  const [showModal, setShowModal] = React.useState(false);
+  const [handleContinue] = usePrompt(
+    () => {
+      setShowModal(true);
+      return false;
+    },
+    () => getMessage(message),
+    history,
+    when,
+  );
+  return (
+    <DefaultModal
+      {...modalOptions}
+      message={getMessage(message)}
+      open={when && showModal}
+      onConfirm={() => {
+        setShowModal(false);
+        handleContinue();
+        modalOptions.onConfirm && modalOptions.onConfirm();
+      }}
+      onCancel={() => {
+        setShowModal(false);
+        modalOptions.onConfirm && modalOptions.onCancel();
+      }}
+    />
+  );
+};
+
+const StyledActionLink = styled(ActionLink)`
+  padding: 0 ${distance.large};
+`;
+
+const DefaultModal: React.FC<PromptDefaultModalProps> = ({
+  title,
+  message,
+  confirmText = 'Ok',
+  cancelText = 'Cancel',
+  onConfirm,
+  onCancel,
+  open,
+}) => {
+  return (
+    <Modal open={open}>
+      <ModalHeader title={title} />
+      {typeof message === 'string' && <ModalBody>{message}</ModalBody>}
+      <ModalFooter>
+        <StyledActionLink onClick={onCancel}>{cancelText}</StyledActionLink>
+        <Button onClick={onConfirm}>{confirmText}</Button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/src/components/Prompt/usePrompt.ts
+++ b/src/components/Prompt/usePrompt.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState, useCallback } from 'react';
+import { PromptHistory, PromptLocation, PromptCallback } from './Prompt.types';
+
+let unblock: any;
+
+export function usePrompt(
+  onRequestToLeavePage: PromptCallback,
+  onRequestToLeaveApp?: PromptCallback,
+  history?: PromptHistory,
+  isEnabled: boolean = false,
+) {
+  const [location, setLocation] = useState<PromptLocation>();
+  const [currentLocation, setCurrentLocation] = useState<PromptLocation>();
+
+  const enable = useCallback(() => {
+    if (history) {
+      if (unblock) {
+        unblock();
+      }
+      unblock = history.block(loc => {
+        setLocation(loc);
+        setCurrentLocation(history.location);
+        return onRequestToLeavePage();
+      });
+    }
+  }, [onRequestToLeavePage, history]);
+
+  const disable = useCallback(() => {
+    if (unblock) {
+      unblock();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isEnabled) {
+      enable();
+      window.addEventListener('beforeunload', handleBeforeUnload);
+    } else {
+      disable();
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    }
+    return () => {
+      disable();
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [isEnabled, enable, disable]);
+
+  const handleBeforeUnload = useCallback(
+    (ev: BeforeUnloadEvent) => {
+      if (isEnabled && onRequestToLeaveApp) {
+        ev.preventDefault();
+        const msg = onRequestToLeaveApp();
+        ev.returnValue = msg;
+        return msg;
+      }
+      return undefined;
+    },
+    [isEnabled, onRequestToLeaveApp],
+  );
+
+  const handleContinue = () => {
+    disable();
+    if (location && currentLocation && history) {
+      history.push(formUrl(location));
+      if (currentLocation.pathname === location.pathname && isEnabled) {
+        enable();
+      }
+    }
+  };
+
+  return [handleContinue, disable];
+}
+
+const formUrl = ({ pathname, search, hash }: PromptLocation) => `${pathname}${search}${hash}`;


### PR DESCRIPTION
Current implementation of Prompt component uses only browser's system dialog. This update brings possibility to use Modal Dialog from precise-ui as well as gives more flexibility with `usePrompt` hook, if modal needs to be further customized

## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

[Place a meaningful description here.]
