### PR TITLE
Bugfix/334 AutocompleteTagBuilder component does not have functional onBlur and onFocus props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.5.2
 
 - Fix sorting of `Table` and `AccordionTable` when groups are defined
+- Fix `onBlur` and `onFocus` props for `AutocompleteTagBuilder` component
 
 ## 1.5.1
 

--- a/src/components/AutocompleteTagBuilder/AutocompleteTagBuilder.int.part.tsx
+++ b/src/components/AutocompleteTagBuilder/AutocompleteTagBuilder.int.part.tsx
@@ -200,6 +200,8 @@ export class AutocompleteTagBuilderInt<T> extends React.Component<
       info,
       borderless = false,
       error,
+      onBlur,
+      onFocus,
     } = this.props;
 
     const { inputValue } = this.state;
@@ -220,6 +222,8 @@ export class AutocompleteTagBuilderInt<T> extends React.Component<
         info={info}
         error={error}
         borderless={borderless}
+        onBlur={onBlur}
+        onFocus={onFocus}
       />
     );
   }


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Fix for #334. 
**Issue:**
In the AutocompleteTagBuildercomponent, the props onBlur and onFocus did not work. If you passed a function to the onBlur prop, this function was never called. The same applied for the onFocus prop. 
**Solution:**
The issue is fixed, by passing the onBlur and onFocus props to the Autocomplete on the AutocompleteTagBuilder component.
