### PR TITLE
Bugfix/342 radio button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Precise UI Changelog
 
+## 1.6.2
+
+- Change to `flex-base: auto` for `RadioButtonCircle` to work on different box-sizing models
+
 ## 1.6.1
 
 - Removed unused dependencies (`css-loader`,`file-loader`,`html-webpack-plugin`,`postcss-loader`,`sass-loader`,`style-loader`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Precise UI React component library powered by Styled Components.",
   "keywords": [
     "react",

--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -86,7 +86,7 @@ const RadioButtonCircle = styled.div(
   vertical-align: middle;
   position: relative;
   overflow: hidden;
-  flex: 0 0 0.5em;
+  flex: 0 0 auto;
   padding: 0.1875em;
   border: 2px solid ${ui5};
   border-radius: 100%;


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

- [x] Bug fix for issue #342 
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

### Description

By using `flex: 0 0 auto;` we allow the `RadioButtonCircle` to adjust the element size automatically based on boxing model and font size.
Since the `SelectMark` already has a fixed `width` and `height` set, the auto wrapper should work well with `auto`.

**Tested for latest version of the following browsers:** 
1. Chrome
2. Chromium
2. Firefox
3. MS Edge
4. IE11
