### PR TITLE
Add CNAME and Trigger on Published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
   release:
     types:
-      - created
+      - published
 
 env:
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -26,6 +26,7 @@ jobs:
         npm run build:demo
         cd styleguide
         ln -s index.html 404.html
+        echo "www.precise-ui.io" > CNAME
     - name: Deploy with gh-pages
       run: |
         git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -3,7 +3,7 @@ name: Demo Page CI
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   deploy_www:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Precise UI Changelog
 
+## 2.1.5
+
+- Improved trigger and added CNAME to kitchen sink
+
 ## 2.1.4
 
 - Updated `Highlight` component to have optional highlight prop (#280)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Precise UI React component library powered by Styled Components.",
   "keywords": [
     "react",


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Previously we used the `created` trigger for released. This one, however, does not fire if one goes via a "draft release" first.

Also, since we use a custom DNS for the kitchen sink we should add it to a `CNAME` file. Otherwise, GitHub may reset the custom setting.
