### PR TITLE
Fixed controlled mode on Pagination component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Precise UI Changelog
 
+## 2.1.6
+
+- Fixed controlled mode on Pagination component
+
 ## 2.1.5
 
 - Improved trigger and added CNAME to kitchen sink

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Precise UI React component library powered by Styled Components.",
   "keywords": [
     "react",

--- a/src/components/Pagination/index.test.tsx
+++ b/src/components/Pagination/index.test.tsx
@@ -62,4 +62,22 @@ describe('<Pagination />', () => {
     );
     expect(wrapper.find('.foo')).toHaveLength(2);
   });
+
+  it('should respect the `value` property', () => {
+    const wrapper = enzyme.mount(
+      <Pagination size={3}>
+        <div className="foo">First</div>
+        <div className="foo">Second</div>
+        <div className="foo">3</div>
+        <div className="foo">4</div>
+        <div className="foo">5</div>
+        <div className="foo">6</div>
+        <div className="foo">7</div>
+      </Pagination>,
+    );
+    
+    wrapper.setProps({value: 2})
+
+    expect(wrapper.find('.foo')).toHaveLength(1);
+  });
 });

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -108,6 +108,18 @@ export class Pagination extends React.Component<PaginationProps, PaginationState
     };
   }
 
+  static getDerivedStateFromProps(props: PaginationProps, state: PaginationState) {
+    const { value } = props;
+
+    if (typeof value === 'number' && state.current !== value) {
+      return {
+        current: value,
+      };
+    }
+
+    return state;
+  }
+
   private handlePageChange = ({ page }: PaginationBarPageChangedEvent) => {
     const { onChange, value } = this.props;
 


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Pagination component has a property called `value` that is meant for switching component into controlled mode by providing current page value. 

However, component only used `value` property in the constructor and did not react of the further property changes.

PR fixes that issue and adds a unit test to verify proper behavior. 
