### PR TITLE
Bugfix/dropdown hight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Precise UI Changelog
 
+## 2.1.8
+
+- Fixed max height dropdown
+
 ## 2.1.7
 
 - Fix `onChange` double trigger on clicking `AccordionTable` expand icon

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Precise UI React component library powered by Styled Components.",
   "keywords": [
     "react",

--- a/src/components/DropdownField/DropdownFieldInt.tsx
+++ b/src/components/DropdownField/DropdownFieldInt.tsx
@@ -89,7 +89,7 @@ const StyledStandardWrapper = styled('ul')<StyledStandardWrapperProps>`
     ${themed<StyledStandardWrapperProps>(({ border, theme: { ui0, ui4 } }) =>
       border === InteractiveListBorderType.none ? ui0 : ui4,
     )};
-  max-height: 50vh;
+  max-height: 40vh;
   ${props =>
     props.direction === InteractiveListDirection.normal
       ? 'border-top-color: transparent'


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

### Description

Dropdown Elements had a height of 50%. Which will lead to a cut view of elements. 
Reason is because drowdown has a top:-53px. 
This fix changed it to 40% to be on the save side and to make sure that the drowdown is not out of the screen on the top
