### PR TITLE
Fix: move @types/react-datepicker from devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3917,8 +3917,7 @@
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "dev": true
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/puppeteer": {
       "version": "1.12.1",
@@ -3933,7 +3932,6 @@
       "version": "16.14.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.14.tgz",
       "integrity": "sha512-uwIWDYW8LznHzEMJl7ag9St1RsK0gw/xaFZ5+uI1ZM1HndwUgmPH3/wQkSb87GkOVg7shUxnpNW8DcN0AzvG5Q==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3944,7 +3942,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-4.1.5.tgz",
       "integrity": "sha512-KGejyyCiFhBXjHp4AmuzO4W4pfWV9PYFZrBTA56tsuy+jpqQ2Jdx7j44onYomeUSv2B2uqT3OCkOh+dOI8Fy3g==",
-      "dev": true,
       "requires": {
         "@popperjs/core": "^2.9.2",
         "@types/react": "*",
@@ -3956,7 +3953,6 @@
           "version": "2.2.5",
           "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
           "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
-          "dev": true,
           "requires": {
             "react-fast-compare": "^3.0.1",
             "warning": "^4.0.2"
@@ -4006,8 +4002,7 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -7113,8 +7108,7 @@
     "csstype": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
-      "dev": true
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "cwd": {
       "version": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.9.2",
+    "@types/react-datepicker": "^4.1.5",
     "date-fns": "^2.23.0",
     "memoize-one": "^5.1.0",
     "react-datepicker": "^4.2.1",
@@ -68,7 +69,6 @@
     "@types/jest-image-snapshot": "^2.8.0",
     "@types/puppeteer": "^1.12.1",
     "@types/react": "^16.14.14",
-    "@types/react-datepicker": "^4.1.5",
     "@types/react-dom": "^16.9.14",
     "@types/react-onclickoutside": "^6.7.0",
     "@types/react-router": "^4.4.1",


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

### Description

If `DateFeild` is used in zeisslet, it can't be built when `@types/react-datepicker` is in `devDependencies`. I have moved it to `dependencies`