### PR TITLE
WCAG: PreciseUI table has wrong header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Precise UI Changelog
 
+## 2.1.10
+
+- Fix WCAG error: Empty table header
+
 ## 2.1.9
 
 - Fixed `arrowToggle` on `AccordionTable`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Precise UI React component library powered by Styled Components.",
   "keywords": [
     "react",

--- a/src/components/Table/TableBasic.part.tsx
+++ b/src/components/Table/TableBasic.part.tsx
@@ -42,6 +42,7 @@ const StyledTable = styled.table<StyledTableProps>(
     border: ${borderless ? 'none' : theme.tableBorder};
 
     > thead > tr > th,
+    > thead > tr > td,
     > tbody > tr > td {
       padding: ${condensed ? `${distance.small} ${distance.large}` : theme.tableHeadPadding};
 
@@ -245,8 +246,11 @@ export class TableBasic<T> extends React.Component<TableProps<T> & RefProps, Tab
               const width = typeof column === 'string' ? undefined : column.width;
               const sortable = this.isSortable(key, columns);
               const direction = sortable && sortBy && (sortBy.columnKey !== key ? undefined : sortBy.order);
+              const headTag = `${name}`.trim() ? 'th' : 'td';
+
               return (
                 <StyledTableHeader
+                  as={headTag}
                   sortable={sortable}
                   width={width}
                   key={key}


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Accoring to WCAG 2 validator, there is `Empty table header` error.

**What does the Empty Table Header error mean?**

An empty table header error means that one of the table headers on your post or page does not contain any text. This means that the `<th>` element is present but looks like this `<th></th>` with nothing between the opening and closing tags.

**How to Fix It**

If the table cell is a header, provide text within the cell that describes the column or row. **If the cell is not a header or must remain empty (such as the top-left cell in a data table), make the cell a `<td>` rather than a `<th>`**.

So, if `<th></th>` is empty, I render it as `<td></td>` (styling kept the same).