### PR TITLE
#373 add page size event to pagination component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Precise UI Changelog
 
+## 2.1.11
+
+- fixed issue 373, passed onSizeChanged event as a prop to the Pagination component
 ## 2.1.10
 
 - Fix WCAG error: Empty table header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.11
 
 - fixed issue 373, passed onSizeChanged event as a prop to the Pagination component
+
 ## 2.1.10
 
 - Fix WCAG error: Empty table header

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "Precise UI React component library powered by Styled Components.",
   "keywords": [
     "react",

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -9,6 +9,12 @@ export interface PaginationChangeEvent {
    */
   value: number;
 }
+export interface PaginationSizeChangeEvent {
+  /**
+   * The current item size per page.
+   */
+  value: number;
+}
 
 export interface PaginationState {
   current: number;
@@ -68,6 +74,10 @@ export interface PaginationProps extends StandardProps {
    * Event fired when the selected page changes.
    */
   onChange?(e: PaginationChangeEvent): void;
+  /**
+   * Event fired when the size per page changes.
+   */
+  onSizeChanged?(e: PaginationSizeChangeEvent): void;
   /**
    * The optional footer info label override, e.g., for localization.
    */
@@ -137,7 +147,7 @@ export class Pagination extends React.Component<PaginationProps, PaginationState
   };
 
   private handleSizeChange = ({ size }: PaginationBarSizeChangedEvent) => {
-    const { children } = this.props;
+    const { children, onSizeChanged } = this.props;
     const { current } = this.state;
     const total = React.Children.count(children);
     const maxPageCount = Math.max(Math.ceil(total / size) - 1, 0);
@@ -145,6 +155,12 @@ export class Pagination extends React.Component<PaginationProps, PaginationState
       size,
       current: Math.min(current, maxPageCount),
     });
+
+    if (typeof onSizeChanged === 'function') {
+      onSizeChanged({
+        value: size,
+      });
+    }
   };
 
   private getDim(count: number) {


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

### Description

In this pull request, I added the ability for the Pagination component to pass the on size changed event as a prop that can be listened for. This is required to correctly compute pagination when pagination is handled in a controlled manner. 
