### PR TITLE
Fix WCAG error: Empty table header in case of JSX element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Precise UI Changelog
 
+## 2.1.13
+
+- Fix WCAG error: Empty table header in case of JSX element
+
 ## 2.1.12
 
 - Fix the issue `The component Styled(styled.span) has been created dynamically`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "Precise UI React component library powered by Styled Components.",
   "keywords": [
     "react",

--- a/src/components/Table/TableBasic.part.tsx
+++ b/src/components/Table/TableBasic.part.tsx
@@ -246,7 +246,7 @@ export class TableBasic<T> extends React.Component<TableProps<T> & RefProps, Tab
               const width = typeof column === 'string' ? undefined : column.width;
               const sortable = this.isSortable(key, columns);
               const direction = sortable && sortBy && (sortBy.columnKey !== key ? undefined : sortBy.order);
-              const headTag = `${name}`.trim() ? 'th' : 'td';
+              const headTag = typeof name === 'string' && name.trim() ? 'th' : 'td';
 
               return (
                 <StyledTableHeader


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

According to WCAG 2 validator, there is "Empty Table Header" error when adding a JSX element on the header.

What does the "Empty Table Header" error mean?

An empty table header error means that one of the table headers on your post or page does not contain any text. This means that the element is present but looks like this with nothing between the opening and closing tags.

The following PR: https://github.com/ZEISS/precise-ui/pull/372, fixed the case where no text or an empty text was displayed. However, the issue persists when a JSX element is part of the table header.
