### PR TITLE
Fix pagination controls on narrow screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Precise UI Changelog
 
+## 2.1.14
+
+- Fix crumbled pagination controls on narrow screens
+
 ## 2.1.13
 
 - Fix WCAG error: Empty table header in case of JSX element

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "2.1.11",
+  "version": "2.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "description": "Precise UI React component library powered by Styled Components.",
   "keywords": [
     "react",

--- a/src/components/Pagination/__snapshots__/index.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/index.test.tsx.snap
@@ -128,6 +128,9 @@ exports[`<Pagination /> should be able to use a custom host 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -678,6 +681,9 @@ exports[`<Pagination /> should be able to use an in-built host 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;

--- a/src/components/PaginationBar/index.tsx
+++ b/src/components/PaginationBar/index.tsx
@@ -30,6 +30,7 @@ function getPages(itemsPerPage: number, total: number) {
 
 const ControlsContainer = styled.div`
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   margin-left: auto;
   align-items: center;


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

The controls inside the pagination bar are smashed on narrow screens. Allowing them to wrap inside the flex container prevents this. With this fix, pagination controls look acceptable at screen widths of 270+ px.
