### PR TITLE
Improve validation of Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Precise UI Changelog
 
+## 2.1.14
+
+- Improve validation of `Form`
+
 ## 2.1.13
 
 - Fix WCAG error: Empty table header in case of JSX element

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -2,7 +2,13 @@
   "ignorePatterns": [
     {
       "pattern": "^https://stackoverflow.com/tags/"
+    },
+    {
+      "pattern": "^https://guides.github.com/"
     }
   ],
-  "aliveStatusCodes": [429, 200]
+  "aliveStatusCodes": [
+    429,
+    200
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "description": "Precise UI React component library powered by Styled Components.",
   "keywords": [
     "react",

--- a/src/common.ts
+++ b/src/common.ts
@@ -488,6 +488,10 @@ export interface InputProps<T> extends StandardProps {
    * Sets maximum lenngth of input field.
    */
   maxLength?: number;
+  /**
+   * List of fields, that need to be revalidated when the field value is changed
+   */
+  validateWith?: Array<string>;
 }
 
 export interface LabeledInputProps<T> extends InputProps<T> {

--- a/src/components/Autocomplete/index.tsx
+++ b/src/components/Autocomplete/index.tsx
@@ -178,7 +178,7 @@ class AutocompleteInt<T> extends React.Component<SupportedAutocompleteProps<T> &
     const { onChange, name = '', form } = this.props;
 
     if (!this.state.controlled) {
-      form ? form.change({ name, value }) : this.setState({ value });
+      form ? form.change({ name, value, validateWith: this.props.validateWith }) : this.setState({ value });
     }
 
     suggestionSelected ? this.hide() : this.show();

--- a/src/components/AutocompleteTagBuilder/AutocompleteTagBuilder.int.part.tsx
+++ b/src/components/AutocompleteTagBuilder/AutocompleteTagBuilder.int.part.tsx
@@ -92,6 +92,7 @@ export class AutocompleteTagBuilderInt<T> extends React.Component<
         form.change({
           name,
           value: newValue,
+          validateWith: this.props.validateWith,
         });
       } else {
         this.setState({

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -159,6 +159,7 @@ export class CheckboxInt extends React.PureComponent<CheckboxProps, CheckboxStat
           form.change({
             name,
             value: checked,
+            validateWith: this.props.validateWith,
           });
         } else {
           this.setState({

--- a/src/components/ColorPicker/index.tsx
+++ b/src/components/ColorPicker/index.tsx
@@ -258,6 +258,7 @@ class ColorPickerInt extends React.PureComponent<ColorPickerProps & FormContextP
       form.change({
         name,
         value: (state as Pick<ColorPickerState, 'value'>).value,
+        validateWith: this.props.validateWith,
       });
     } else {
       this.setState(state);

--- a/src/components/DateField/DateFieldInt.part.tsx
+++ b/src/components/DateField/DateFieldInt.part.tsx
@@ -274,6 +274,7 @@ class DateFieldInt extends React.Component<DateFieldProps, DateFieldState> {
           form.change({
             name,
             value,
+            validateWith: this.props.validateWith,
           });
         this.onOpenChange(true);
       });

--- a/src/components/DropdownField/DropdownFieldInt.tsx
+++ b/src/components/DropdownField/DropdownFieldInt.tsx
@@ -320,6 +320,7 @@ export class DropdownFieldInt extends React.Component<DropdownFieldProps & FormC
         form.change({
           name,
           value,
+          validateWith: this.props.validateWith,
         });
       } else {
         this.setState({

--- a/src/components/Dropzone/index.tsx
+++ b/src/components/Dropzone/index.tsx
@@ -166,6 +166,7 @@ class DropzoneInt extends React.Component<DropzoneProps & FormContextProps, Drop
         form.change({
           name,
           value: multiple ? [...this.state.value, ...files] : files,
+          validateWith: this.props.validateWith,
         });
       } else {
         this.setState(
@@ -250,6 +251,7 @@ class DropzoneInt extends React.Component<DropzoneProps & FormContextProps, Drop
         form.change({
           name,
           value: this.state.value.filter(file => f !== file),
+          validateWith: this.props.validateWith,
         });
       } else {
         this.setState(

--- a/src/components/FileSelect/index.tsx
+++ b/src/components/FileSelect/index.tsx
@@ -107,6 +107,7 @@ class FileSelectInt extends React.Component<FileSelectProps & FormContextProps, 
         form.change({
           name,
           value: getFiles(multiple ? [...this.state.value] : [], files),
+          validateWith: this.props.validateWith,
         });
       } else {
         this.setState(
@@ -130,6 +131,7 @@ class FileSelectInt extends React.Component<FileSelectProps & FormContextProps, 
         form.change({
           name,
           value: this.state.value.filter(file => f !== file),
+          validateWith: this.props.validateWith,
         });
       } else {
         this.setState(

--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -46,6 +46,10 @@ export interface RadioButtonProps extends StandardProps {
    * Name of the radio button within a radio button group.
    */
   name?: string;
+  /**
+   * List of fields, that need to be revalidated when the field value is changed
+   */
+  validateWith?: Array<string>;
 }
 
 export interface RadioButtonIntProps extends RadioButtonProps {
@@ -213,6 +217,7 @@ export class RadioButtonInt extends React.PureComponent<RadioButtonIntProps & Fo
           form.change({
             name,
             value,
+            validateWith: this.props.validateWith,
           });
         } else {
           this.setState({

--- a/src/components/RadioButtonGroup/index.tsx
+++ b/src/components/RadioButtonGroup/index.tsx
@@ -113,6 +113,7 @@ class RadioButtonGroupInt extends React.PureComponent<RadioButtonGroupProps & Fo
             form.change({
               name,
               value,
+              validateWith: this.props.validateWith,
             });
           } else if (value) {
             this.setState({

--- a/src/components/Rating/index.tsx
+++ b/src/components/Rating/index.tsx
@@ -182,6 +182,7 @@ class RatingInt extends React.Component<RatingProps & FormContextProps, RatingSt
         form.change({
           name,
           value,
+          validateWith: this.props.validateWith,
         });
       } else {
         this.setState({

--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -279,6 +279,7 @@ class SliderInt extends React.PureComponent<SliderProps & FormContextProps, Slid
           form.change({
             name,
             value,
+            validateWith: this.props.validateWith,
           });
         } else {
           this.setState({

--- a/src/components/TagBuilder/TagBuilderInt.part.tsx
+++ b/src/components/TagBuilder/TagBuilderInt.part.tsx
@@ -354,6 +354,7 @@ export class TagBuilderInt extends React.Component<TagBuilderProps & FormContext
         form.change({
           name,
           value,
+          validateWith: this.props.validateWith,
         });
       } else {
         this.setState({

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -176,6 +176,7 @@ class TextFieldInt extends React.Component<TextFieldProps & FormContextProps, Te
         form.change({
           name,
           value,
+          validateWith: this.props.validateWith,
         });
       } else {
         this.setState({

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -138,6 +138,7 @@ class ToggleInt extends React.PureComponent<ToggleProps & FormContextProps, Togg
           form.change({
             name,
             value: status,
+            validateWith: this.props.validateWith,
           });
         } else {
           this.setState({

--- a/src/contexts/FormContext.ts
+++ b/src/contexts/FormContext.ts
@@ -14,6 +14,7 @@ export interface FormValueNotifier {
 export interface FormValueChange {
   name: string;
   value: any;
+  validateWith?: Array<string>;
 }
 
 export interface FormContextType {


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

### Description

There are cases when conditional validation of form fields is needed. E.g.,:
- only one of fields need to be filled
- field need to be filled when checkbox is set
- etc
Currently such kind of validation is not supported.

Current PR solves this issue in the following way:
- validator function gets not only value to e validated, but also data of the whole form
- new optional prop `validateWith` is introduced for all form controls - there can be passed list of fields that need to be re-validated when form value is changed.