### PR TITLE
feat: fix react error from onSizeChange in the Pagination component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Precise UI Changelog
 
+## 2.1.15
+
+- Fix React error when onSizeChanged gets added to the Pagination component
+
 ## 2.1.14
 
 - Improve validation of `Form`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "description": "Precise UI React component library powered by Styled Components.",
   "keywords": [
     "react",

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -186,7 +186,7 @@ export class Pagination extends React.Component<PaginationProps, PaginationState
   }
 
   render() {
-    const { children, host, size: sizeProp, itemsInfo, pagesInfo, label, render, ...props } = this.props;
+    const { children, host, size: sizeProp, itemsInfo, pagesInfo, label, render, onSizeChanged, ...props } = this.props;
     const count = React.Children.count(children);
     const { current, min, max, sizeState } = this.getDim(count);
     const content =


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Currently, the `onSizeChange` handler gets passed down with prop spreading to a different component. This leads to an error in the console, as the prop gets attached to a basic HTML element.
<img width="929" alt="grafik" src="https://user-images.githubusercontent.com/7814926/178580438-dc8cc4ed-5213-43cb-a7dd-fbc334ae7499.png">

This fix removes the handler from the standard props before they are passed down.

1. The handler was introduced here https://github.com/ZEISS/precise-ui/pull/374. 
2. It gets passed down into the `PaginationLayout` here: https://github.com/ZEISS/precise-ui/blob/main/src/components/Pagination/index.tsx#L216
3. And added to a `div` here: https://github.com/ZEISS/precise-ui/blob/main/src/components/Pagination/PaginationLayout.part.tsx#L22

