### PR TITLE
feat: make some component types compatible with react 18

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -417,6 +417,11 @@ export interface StandardProps {
    * The style prop for explicitly overriding some CSS styles.
    */
   style?: React.CSSProperties;
+  /**
+   * Make it compatible with React 18, where React.FC and React.Component are missing
+   * the default children prop.
+   */
+  children?: React.ReactNode | undefined;
 }
 
 export interface InputChangeEvent<T> {

--- a/src/common.ts
+++ b/src/common.ts
@@ -417,11 +417,6 @@ export interface StandardProps {
    * The style prop for explicitly overriding some CSS styles.
    */
   style?: React.CSSProperties;
-  /**
-   * Make it compatible with React 18, where React.FC and React.Component are missing
-   * the default children prop.
-   */
-  children?: React.ReactNode | undefined;
 }
 
 export interface InputChangeEvent<T> {

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -3,6 +3,7 @@ import styled from '../../utils/styled';
 import { Prompt } from '../Prompt';
 import { FormContext, FormContextType, FormValueNotifier, FormValueChange } from '../../contexts';
 import { StandardProps } from '../../common';
+import { ReactComponentDefaultProps } from '../../utils/react-18-compat';
 
 export interface FormSubmitEvent {
   /**
@@ -50,7 +51,7 @@ export interface FormValidationError {
   error: React.ReactChild;
 }
 
-export interface FormProps<FormValues> extends StandardProps {
+export interface FormProps<FormValues> extends StandardProps, ReactComponentDefaultProps {
   /**
    * Shows the given message if the user wants to navigate
    * with changes being made or renders custom component with message if provided.
@@ -351,6 +352,7 @@ export class Form<Values extends FormValuesData> extends React.Component<FormPro
       prompt,
       ...rest
     } = this.props;
+
     const { changed } = this.state;
     return (
       <StyledForm {...rest} onSubmit={this.submit}>

--- a/src/components/PaddedContainer/index.tsx
+++ b/src/components/PaddedContainer/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import styled, { css } from '../../utils/styled';
 import { distance } from '../../distance';
+import { ReactFC } from '../../utils/react-18-compat';
 
 export interface PaddedContainerProps {
   /**
@@ -40,6 +41,6 @@ const StyledContainer = styled('div')<PaddedContainerProps>(
   `,
 );
 
-export const PaddedContainer: React.FC<PaddedContainerProps> = props => {
+export const PaddedContainer: ReactFC<PaddedContainerProps> = props => {
   return <StyledContainer {...props} />;
 };

--- a/src/components/PaddedContainer/index.tsx
+++ b/src/components/PaddedContainer/index.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import styled, { css } from '../../utils/styled';
 import { distance } from '../../distance';
-import { ReactFC } from '../../utils/react-18-compat';
+import { ReactComponentDefaultProps } from '../../utils/react-18-compat';
 
-export interface PaddedContainerProps {
+export interface PaddedContainerProps extends ReactComponentDefaultProps {
   /**
    * Padding on top. Valid values: xxsmall, xsmall, small, medium, large, xlarge, xxlarge, xxxlarge.
    */
@@ -41,6 +41,6 @@ const StyledContainer = styled('div')<PaddedContainerProps>(
   `,
 );
 
-export const PaddedContainer: ReactFC<PaddedContainerProps> = props => {
+export const PaddedContainer: React.FC<PaddedContainerProps> = props => {
   return <StyledContainer {...props} />;
 };

--- a/src/utils/react-18-compat.ts
+++ b/src/utils/react-18-compat.ts
@@ -3,15 +3,8 @@ import * as React from 'react';
 /**
  * This interface needs to be added to a property type that is used on `React.Component`.
  *
- * With React 18, React.Component doesn't include children types anymore.
+ * With React 18, React.Component and React.FC don't include children types anymore.
  */
 export interface ReactComponentDefaultProps {
   children?: React.ReactNode | undefined;
 }
-
-/**
- * This interface is a replacement for React.FC type to make it compatible with React 18 consumers.
- *
- * With React 18, React.FC doesn't include children types anymore.
- */
-export interface ReactFC<G = {}> extends React.FC<G>, ReactComponentDefaultProps {}

--- a/src/utils/react-18-compat.ts
+++ b/src/utils/react-18-compat.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+/**
+ * This interface is a replacement for React.FC type to make it compatible with React 18 consumers.
+ *
+ * With React 18, the React.FC interface was changed to not include the children by default.
+ */
+export interface ReactFC<G = {}> extends React.FC<G> {
+  children?: React.ReactNode | undefined;
+}

--- a/src/utils/react-18-compat.ts
+++ b/src/utils/react-18-compat.ts
@@ -1,10 +1,17 @@
 import * as React from 'react';
 
 /**
- * This interface is a replacement for React.FC type to make it compatible with React 18 consumers.
+ * This interface needs to be added to a property type that is used on `React.Component`.
  *
- * With React 18, the React.FC interface was changed to not include the children by default.
+ * With React 18, React.Component doesn't include children types anymore.
  */
-export interface ReactFC<G = {}> extends React.FC<G> {
+export interface ReactComponentDefaultProps {
   children?: React.ReactNode | undefined;
 }
+
+/**
+ * This interface is a replacement for React.FC type to make it compatible with React 18 consumers.
+ *
+ * With React 18, React.FC doesn't include children types anymore.
+ */
+export interface ReactFC<G = {}> extends React.FC<G>, ReactComponentDefaultProps {}


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

We are using precise-ui in a react 18 project. Since react 18, `React.FC` doesn't have the `children` prop anymore. Therefore, we get a Typescript error as soon as we add a child to a component that uses `React.FC`.

In order to keep the change minimal, I did 2 things:
- Create a interface `ReactComponentDefaultProps` that can be used to extend property types for `React.Component`.
- Created a `ReactFC` interface, that can be used as a drop-in replacement for `React.FC`

I didn't replace all `React.FC` components with `ReactFC`, but only the ones we need right now to keep the change minimal.
