### PR TITLE
Make dynamically created Headline static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Precise UI Changelog
 
+## 2.1.17
+
+- Make dynamically created Headline subcomponents static
+
 ## 2.1.16
 
 - Fix some typings for React 18 compatibility.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precise-ui",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "description": "Precise UI React component library powered by Styled Components.",
   "keywords": [
     "react",

--- a/src/components/Headline/Headline.test.tsx
+++ b/src/components/Headline/Headline.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { Headline } from './';
 import { light } from '../../themes';
 

--- a/src/components/Headline/index.tsx
+++ b/src/components/Headline/index.tsx
@@ -6,12 +6,14 @@ import { getFontStyle } from '../../textStyles';
 
 export type HeadlineSize = 'small' | 'medium';
 
+export type HeadlineLevel = keyof typeof styledHeadlines;
+
 export interface HeadlineProps extends StandardProps {
   /**
    * Represent 5 levels of headings (1-5)
    * Default is 3
    */
-  level?: 1 | 2 | 3 | 4 | 5;
+  level?: HeadlineLevel;
   /**
    * When specified headline will have muted text color
    */
@@ -24,67 +26,55 @@ export interface HeadlineProps extends StandardProps {
 
 export interface StyledHeadlineProps {
   size: HeadlineSize;
-  level: number;
+  level: HeadlineLevel;
   theme?: any;
   subheader?: boolean;
 }
 
-interface HeadlineCache {
-  [key: string]: any;
-}
+/**
+ * A common style for all headline levels.
+ */
+const baseStyle = themed<StyledHeadlineProps>(
+  props => css`
+    margin: 0;
+    padding: ${props.theme.headingsPadding || `0 ${distance.small} 0 0`};
+    font-family: ${props.theme.fontFamily || 'inherit'};
+    color: ${props.subheader ? props.theme.text5 : 'inherit'};
+  `,
+);
 
-const Headlines: HeadlineCache = {};
-
-function getComponentName(level: number) {
-  return `h${level >= 1 && level <= 5 ? level : 3}`;
-}
-
-function getHeadlineStyle(level: StyledHeadlineProps['level']) {
-  switch (level) {
-    case 1:
-      return getFontStyle({ size: 'xxxLarge', weight: 'light' });
-    case 2:
-      return getFontStyle({ size: 'xxLarge', weight: 'light' });
-    case 3:
-      return getFontStyle({ size: 'xLarge', weight: 'medium' });
-    case 4:
-      return getFontStyle({ size: 'large', weight: 'regular' });
-    case 5:
-      return getFontStyle({ size: 'medium', weight: 'medium' });
-    default:
-      return '';
-  }
-}
-
-function getStyledHeadline(level: number) {
-  const component = getComponentName(level);
-  const Headline = Headlines[component];
-
-  if (!Headline) {
-    const NewHeadline = styled(component as 'h1')<StyledHeadlineProps>(
-      themed<StyledHeadlineProps>(
-        props => css`
-          ${getHeadlineStyle(props.level)}
-
-          margin: 0;
-          padding: ${props.theme.headingsPadding || `0 ${distance.small} 0 0`};
-          font-family: ${props.theme.fontFamily || 'inherit'};
-          color: ${props.subheader ? props.theme.text5 : 'inherit'};
-        `,
-      ),
-    );
-    Headlines[component] = NewHeadline;
-    return NewHeadline;
-  }
-
-  return Headline;
-}
+/**
+ * A map of styled components for each headline level.
+ */
+const styledHeadlines = {
+  1: styled.h1`
+    ${getFontStyle({ size: 'xxxLarge', weight: 'light' })}
+    ${baseStyle}
+  `,
+  2: styled.h2`
+    ${getFontStyle({ size: 'xxLarge', weight: 'light' })}
+    ${baseStyle}
+  `,
+  3: styled.h3`
+    ${getFontStyle({ size: 'xLarge', weight: 'medium' })}
+    ${baseStyle}
+  `,
+  4: styled.h4`
+    ${getFontStyle({ size: 'large', weight: 'regular' })}
+    ${baseStyle}
+  `,
+  5: styled.h5`
+    ${getFontStyle({ size: 'medium', weight: 'medium' })}
+    ${baseStyle}
+  `,
+};
 
 /**
  * Headline component with styles for all headline levels.
  */
 export const Headline: React.SFC<HeadlineProps> = ({ level = 3, children, ...rest }) => {
-  const StyledHeadline = getStyledHeadline(level);
+  const StyledHeadline = styledHeadlines[level] || styledHeadlines[3];
+
   return (
     <StyledHeadline level={level} {...rest}>
       {children}


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

### Description

This change defines all heading components statically (in the moment of import) in order to get rid of this warning in console:

<img width="254" alt="image" src="https://user-images.githubusercontent.com/76123820/204740778-70f6ffc5-9578-4c62-bd50-aa96f281a353.png">

